### PR TITLE
Adding error msg to send to LLM in case of failed request activation

### DIFF
--- a/elements/elements/base.py
+++ b/elements/elements/base.py
@@ -37,26 +37,26 @@ class ElementState(enum.Enum):
 class BaseElement:
     """
     Base class for all elements in the Bot Framework.
-    
+
     In the component-based architecture, Elements are minimal structural nodes
     that primarily maintain ID, name, and parent references. All state and behavior
     are implemented by Components attached to the Element.
-    
+
     Elements:
     - Have a unique ID and name
-    - Can be mounted in a parent element 
+    - Can be mounted in a parent element
     - Can have multiple Components attached to provide functionality
     - Are structural nodes in the scene graph
     - Delegate most functionality to their attached Components
     """
-    
+
     # Whether this element is a Space (contains other elements) or an Object
     IS_SPACE: bool = False
-    
+
     def __init__(self, element_id: str, name: str, description: str):
         """
         Initialize the base element.
-        
+
         Args:
             element_id: Unique identifier for this element
             name: Human-readable name for this element
@@ -65,42 +65,42 @@ class BaseElement:
         self.id = element_id
         self.name = name
         self.description = description
-        
+
         # Parent element (where this element is mounted)
         self._parent_element: Optional[Tuple[str, MountType]] = None
-        
+
         # Registry reference (for sending messages to activity layer)
         self._registry = None
-        
+
         # Components
         self._components: Dict[str, 'Component'] = {}
-        
+
         logger.info(f"Created element: {name} ({element_id})")
-        
+
         # Note: Components are typically added by subclasses or factories *after* base init.
-        # Therefore, calling validation here might be too early. 
+        # Therefore, calling validation here might be too early.
         # Let's add the validation method here, but the call should likely be moved
         # to the end of the subclass __init__ or the factory construction process.
         # self._validate_all_component_dependencies() # <<< Tentatively place call here, but see note.
-    
+
     def get_registry(self):
         """
         Get the SpaceRegistry reference.
-        
+
         Returns:
             The SpaceRegistry instance if set, None otherwise
         """
         from ..space_registry import SpaceRegistry
         return SpaceRegistry.get_instance()
-    
+
     def add_component(self, component_type: Type['Component'], **kwargs) -> Optional['Component']:
         """
         Add a component to this element.
-        
+
         Args:
             component_type: Type of component to add
             **kwargs: Additional arguments to pass to the component constructor
-        
+
         Returns:
             The added component, or None if the component could not be added
         """
@@ -113,69 +113,69 @@ class BaseElement:
         except Exception as e:
             logger.error(f"Error creating component of type {component_type.__name__} for {self.id}: {e}, kwargs: {kwargs}", exc_info=True)
             return None
-        
+
         # Check if we already have a component of this type
         if self.get_component_by_type(component.COMPONENT_TYPE):
              logger.warning(f"Element {self.id} already has a component of type {component.COMPONENT_TYPE}. Cannot add duplicate.")
              return None
-        
+
         # Initialize the component
         try:
             component.initialize()
-        except BaseException as e:    
+        except BaseException as e:
             logger.error(f"Failed to initialize component {component.COMPONENT_TYPE}: {e}", exc_info=True)
             return None
-        
+
         # Add to components dictionary using component type as key for easier lookup?
         # Or use component.id? Let's stick with component.id for now as it seems to be the current pattern elsewhere.
-        comp_id = component.id 
+        comp_id = component.id
         self._components[comp_id] = component
-        
+
         logger.debug(f"Added component {component.COMPONENT_TYPE} ({comp_id}) to element {self.id}")
         return component
-    
+
     def remove_component(self, component_id: str) -> bool:
         """
         Remove a component from this element.
-        
+
         Args:
             component_id: ID of the component to remove
-            
+
         Returns:
             True if the component was removed, False otherwise
         """
         if component_id not in self._components:
             return False
-        
+
         component = self._components[component_id]
-        
+
         # Check for dependents
         for other_comp in self._components.values():
             if component.COMPONENT_TYPE in other_comp.DEPENDENCIES:
                 logger.warning(f"Cannot remove component {component.COMPONENT_TYPE}: it is a dependency for {other_comp.COMPONENT_TYPE}")
                 return False
-        
+
         # Cleanup and remove
         if not component.cleanup():
             logger.warning(f"Component {component.COMPONENT_TYPE} reported cleanup failure")
-        
+
         del self._components[component_id]
         logger.debug(f"Removed component {component.COMPONENT_TYPE} from element {self.id}")
-        
+
         return True
-    
+
     def get_component(self, component_id: str) -> Optional['Component']:
         """
         Get a component by ID.
-        
+
         Args:
             component_id: ID of the component to get
-            
+
         Returns:
             The component, or None if not found
         """
         return self._components.get(component_id)
-    
+
     def get_component_by_type(self, component_type: Union[str, Type[Component]]) -> Optional[Component]:
         """Get a component by its type (class or string identifier)."""
         target_type_name = component_type if isinstance(component_type, str) else component_type.COMPONENT_TYPE
@@ -199,60 +199,60 @@ class BaseElement:
             elif hasattr(comp, 'COMPONENT_TYPE') and comp.COMPONENT_TYPE == target_type_name:
                 matches.append(comp)
         return matches
-    
+
     def get_components(self) -> Dict[str, 'Component']:
         """
         Get all components.
-        
+
         Returns:
             Dictionary of component ID to component instance.
         """
         return self._components
-    
+
     def handle_event(self, event: Dict[str, Any], timeline_context: Dict[str, Any]) -> bool:
         """
         Handle an event by delegating to components.
-        
+
         Args:
             event: Event data
             timeline_context: Timeline context for this event
-            
+
         Returns:
             True if the event was handled by any component, False otherwise
         """
         # Delegate event to all components
         handled = False
-        
+
         for component in self._components.values():
             if component.handle_event(event, timeline_context):
                 handled = True
-                
+
         return handled
-    
+
     def _set_parent(self, parent_id: str, mount_type: MountType) -> None:
         """
         Set the parent element.
-        
+
         Args:
             parent_id: ID of the parent element
             mount_type: Type of mounting
         """
         self._parent_element = (parent_id, mount_type)
-    
+
     def _clear_parent(self) -> None:
         """Clear the parent element reference."""
         self._parent_element = None
-    
+
     def get_parent_info(self) -> Optional[Dict[str, Any]]:
         """
         Get information about the parent element.
-        
+
         Returns:
             Dictionary with parent ID and mount type, or None if not mounted
         """
         if not self._parent_element:
             return None
-            
+
         parent_id, mount_type = self._parent_element
         return {
             "parent_id": parent_id,
@@ -262,16 +262,16 @@ class BaseElement:
     def get_parent_object(self) -> Optional['BaseElement']: # Or Optional['Space'] might be more accurate if parent is always Space
         """
         Retrieves the actual parent object of this element using the stored parent_id and the SpaceRegistry.
-        
+
         Returns:
             The parent BaseElement (likely a Space instance) or None if not found or if registry is unavailable.
         """
         if not self._parent_element:
             logger.debug(f"[{self.id}] No parent information tuple (_parent_element) available.")
             return None
-        
+
         parent_id, _ = self._parent_element # mount_type is not needed for lookup here
-        
+
         if not parent_id:
             logger.debug(f"[{self.id}] Parent ID is not set in _parent_element tuple.")
             return None
@@ -286,7 +286,7 @@ class BaseElement:
         parent_obj = registry.get_space(parent_id)
         if parent_obj:
             return parent_obj
-        
+
         # Optional: Fallback if the parent might be a non-Space element also registered.
         # For messaging context, parent is almost always a Space.
         # if hasattr(registry, 'get_element'):
@@ -297,21 +297,21 @@ class BaseElement:
 
         logger.warning(f"[{self.id}] Could not find parent object (Space) with ID '{parent_id}' via registry's get_space method.")
         return None
-    
+
     def cleanup(self) -> bool:
         """
         Clean up the element and all its components.
-        
+
         Returns:
             True if cleanup was successful, False otherwise
         """
         success = True
-        
+
         # Clean up all components
         for component_id in list(self._components.keys()):
             if not self.remove_component(component_id):
                 success = False
-        
+
         return success
 
     def _validate_all_component_dependencies(self) -> bool:
@@ -324,7 +324,7 @@ class BaseElement:
         logger.debug(f"Validating dependencies for all components on element {self.id}...")
         all_valid = True
         component_map_by_type = {comp.COMPONENT_TYPE: comp for comp in self._components.values() if hasattr(comp, 'COMPONENT_TYPE')}
-        
+
         for comp_id, component in self._components.items():
             if hasattr(component, 'DEPENDENCIES') and component.DEPENDENCIES:
                 # Check if DEPENDENCIES is a set or list
@@ -337,7 +337,7 @@ class BaseElement:
                      logger.error(f"Component {comp_id} ({component.COMPONENT_TYPE}) has invalid DEPENDENCIES attribute (not a set or list). Skipping validation.")
                      all_valid = False
                      continue
-                     
+
                 for required_type in dependencies_list:
                     if required_type not in component_map_by_type:
                         logger.error(f"Dependency validation FAILED for {comp_id} ({component.COMPONENT_TYPE}): Missing required component type '{required_type}'.")
@@ -358,8 +358,8 @@ class BaseElement:
             logger.debug(f"All component dependencies successfully validated for element {self.id}.")
         else:
             logger.error(f"Dependency validation failed for one or more components on element {self.id}.")
-            
-        return all_valid 
+
+        return all_valid
 
     def finalize_setup(self) -> None:
         """
@@ -375,8 +375,8 @@ class BaseElement:
 
     def _register_component_tools(self) -> None:
         """
-        Iterates through attached components and registers methods 
-        marked as tools (e.g., starting with 'handle_') with this 
+        Iterates through attached components and registers methods
+        marked as tools (e.g., starting with 'handle_') with this
         element's own ToolProviderComponent (if present).
         """
         # Find the ToolProviderComponent on this element
@@ -396,7 +396,7 @@ class BaseElement:
             # Skip the tool provider itself
             if component is tool_provider:
                 continue
-                
+
             # Inspect methods
             for attr_name in dir(component):
                 if attr_name.startswith("handle_"):
@@ -407,13 +407,13 @@ class BaseElement:
                             docstring = inspect.getdoc(attr_value) or ""
                             description = docstring.split('\n')[0] if docstring else f"Tool '{tool_name}' from {component.COMPONENT_TYPE}"
                             param_descriptions = {} # Placeholder
-                            
+
                             # Check if already registered *on this element's provider*
                             if tool_name in tool_provider.list_tools():
                                 logger.debug(f"Tool '{tool_name}' already registered on {self.id}. Skipping registration from {component.COMPONENT_TYPE}.")
                                 skipped_count += 1
                                 continue
-                                
+
                             tool_provider.register_tool_function(
                                 name=tool_name,
                                 description=description,
@@ -424,7 +424,7 @@ class BaseElement:
                             logger.debug(f"Registered tool '{tool_name}' on {self.id} from {component.COMPONENT_TYPE}")
                     except Exception as e:
                         logger.error(f"Error inspecting/registering method {attr_name} from component {comp_id} on element {self.id}: {e}", exc_info=True)
-        
+
         if registered_count > 0 or skipped_count > 0:
             logger.info(f"[{self.id}] Local tool registration complete. Registered: {registered_count}, Skipped: {skipped_count}.")
 
@@ -440,7 +440,7 @@ class BaseElement:
         Receive an event and dispatch it to components.
         This is the standard entry point for an element to process an event.
         Spaces will override this to also record to their timeline first.
-        
+
         Args:
             event_payload: The core data of the event.
             timeline_context: Timeline context (may be less relevant for non-Space elements
@@ -454,11 +454,11 @@ class BaseElement:
     def handle_event(self, event: Dict[str, Any], timeline_context: Dict[str, Any]) -> bool:
         """
         Handle an event by delegating to components.
-        
+
         Args:
             event: Event data (this is the event_payload received by receive_event)
             timeline_context: Timeline context for this event
-            
+
         Returns:
             True if the event was handled by any component, False otherwise
         """

--- a/elements/elements/components/compression_engine_component.py
+++ b/elements/elements/components/compression_engine_component.py
@@ -37,15 +37,15 @@ class CompressionEngineComponent(Component):
     2. Providing memory context to AgentLoop (no compression for now - unlimited context)
     3. Future: Implementing context compression strategies
     4. NEW: Persisting all data to pluggable storage backends (file, SQLite, etc.)
-    
+
     This component centralizes memory management and will evolve to include
     sophisticated compression algorithms for maintaining agent continuity
     within context limits.
     """
-    
+
     COMPONENT_TYPE = "CompressionEngineComponent"
     HANDLED_EVENT_TYPES = ["reasoning_chain_stored", "memory_requested"]
-    
+
     # NEW: Rolling compression token limits - UPDATED for continuous rolling
     FOCUSED_MEMORY_LIMIT = 4000      # 4k tokens of memories for focused elements (down from 20k)
     FOCUSED_FRESH_LIMIT = 30000      # 30k tokens of fresh content for focused elements (down from 50k)
@@ -53,25 +53,25 @@ class CompressionEngineComponent(Component):
     MIN_COMPRESSION_BATCH = COMPRESSION_CHUNK_SIZE     # Minimum excess before triggering compression (avoid micro-compressions)
     UNFOCUSED_TOTAL_LIMIT = 4000     # 4k tokens total for unfocused elements (unchanged)
     MIN_COMPRESSION_THRESHOLD = 1000 # 1k tokens minimum before triggering any compression (avoid compressing small content)
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        
+
         # Track agent identity for consistent messaging
         self._agent_name: Optional[str] = None
-        
+
         # NEW: Phase 3 - Integrated MemoryCompressor for agent-driven memory formation
         self._memory_compressor = None  # Will be AgentMemoryCompressor instance
-        
+
         # NEW: Conversation tracking for proper storage
         self._conversation_id: Optional[str] = None
-        
+
         # Storage tracking
         self._storage = None
         self._storage_initialized = False
-        
+
         logger.info(f"CompressionEngineComponent initialized ({self.id}) - ready for AgentMemoryCompressor integration")
-    
+
     def _on_initialize(self) -> bool:
         """Initialize the compression engine after being attached to InnerSpace."""
         try:
@@ -84,25 +84,25 @@ class CompressionEngineComponent(Component):
             else:
                 # Fallback to component ID
                 self._conversation_id = f"agent_{self.id}"
-            
+
             # Schedule async initialization to run later
             # We can't run async code directly in _on_initialize
-            
+
             async def async_init():
                 try:
                     # Initialize storage backend
                     await self._initialize_storage()
-                    
+
                     # Load existing data from storage
                     await self._load_from_storage()
-                    
+
                     # NEW: Phase 3 - Initialize AgentMemoryCompressor with LLM access
                     await self._initialize_memory_compressor()
-                    
+
                     logger.info(f"CompressionEngine async initialization complete for {self._agent_name}")
                 except Exception as e:
                     logger.error(f"Failed during async initialization: {e}", exc_info=True)
-            
+
             # Try to schedule the async initialization
             try:
                 # Check if we're in an async context
@@ -113,110 +113,110 @@ class CompressionEngineComponent(Component):
             except RuntimeError:
                 # No event loop running, we'll initialize later when needed
                 logger.info(f"No event loop running, will initialize storage on first use for CompressionEngine {self.id}")
-            
+
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to initialize CompressionEngineComponent: {e}", exc_info=True)
             return False
-    
+
     async def _ensure_storage_ready(self) -> bool:
         """Ensure storage backend is initialized before use."""
         if self._storage_initialized:
             return True
-        
+
         if self._storage is None:
             logger.info(f"Storage not yet initialized for CompressionEngine {self.id}, initializing now...")
             success = await self._initialize_storage()
             if not success:
                 return False
-            
+
             # Also load existing data
             await self._load_from_storage()
-        
+
         return self._storage_initialized
-    
+
     async def _initialize_storage(self) -> bool:
         """Initialize the pluggable storage backend."""
         try:
             logger.info(f"Initializing storage backend for CompressionEngine {self.id}")
-            
+
             # Create storage from environment configuration
             self._storage = create_storage_from_env()
-            
+
             # Initialize the storage backend
             success = await self._storage.initialize()
             if not success:
                 logger.error(f"Failed to initialize storage backend")
                 return False
-            
+
             self._storage_initialized = True
             logger.info(f"Storage backend successfully initialized for CompressionEngine {self.id}")
-            
+
             # Test storage health
             health = await self._storage.health_check()
             logger.info(f"Storage health: {health.get('status', 'unknown')}")
-            
+
             return True
-            
+
         except Exception as e:
             logger.error(f"Error initializing storage backend: {e}", exc_info=True)
             return False
-    
+
     async def _load_from_storage(self) -> bool:
         """Load existing conversation data and memories from storage."""
         if not self._storage_initialized or not self._conversation_id:
             return False
-        
+
         try:
             logger.info(f"Loading stored data for conversation {self._conversation_id}")
-            
+
             # Load conversation data (Typingcloud format with compressed memories)
             conversation_data = await self._storage.load_conversation(self._conversation_id)
             if conversation_data:
                 logger.info(f"Loaded existing conversation data for {self._conversation_id}")
                 # TODO: Process conversation data if needed
-            
+
             # Load raw messages (uncompressed message history)
             raw_messages = await self._storage.load_raw_messages(self._conversation_id)
             if raw_messages:
                 logger.info(f"Loaded {len(raw_messages)} raw messages for {self._conversation_id}")
                 # TODO: Process raw messages if needed for recompression
-            
+
             # Load memories (compressed memory formation sequences)
             memories = await self._storage.load_memories(self._conversation_id)
             if memories:
                 logger.info(f"Loaded {len(memories)} memories for {self._conversation_id}")
                 # TODO: Process memories into context
-            
+
             # Load reasoning chains (agent reasoning and tool interaction history)
             agent_id = self._agent_name or self.id
             reasoning_chains = await self._storage.load_reasoning_chains(agent_id)
             if reasoning_chains:
                 # Restore in-memory interactions from stored reasoning chains
                 logger.info(f"Loaded {len(reasoning_chains)} reasoning chains for agent {agent_id}")
-            
+
             return True
-            
+
         except Exception as e:
             logger.error(f"Error loading data from storage: {e}", exc_info=True)
             return False
-    
+
     async def _initialize_memory_compressor(self) -> bool:
         """
         Initialize the AgentMemoryCompressor for agent-driven memory formation.
-        
+
         Phase 3: This replaces simple content summaries with agent reflection.
         """
         try:
             from .agent_memory_compressor import AgentMemoryCompressor
-            
+
             # Get LLM provider for agent reflection
             llm_provider = self._get_llm_provider()
             if not llm_provider:
                 logger.warning(f"LLM provider not available for AgentMemoryCompressor - will use fallback compression")
                 return False
-            
+
             # Create agent-scoped memory compressor
             agent_id = self._agent_name or self.id
             self._memory_compressor = AgentMemoryCompressor(
@@ -225,10 +225,10 @@ class CompressionEngineComponent(Component):
                 storage_base_path="storage_data/memory_storage",
                 llm_provider=llm_provider
             )
-            
+
             logger.info(f"AgentMemoryCompressor initialized for agent {agent_id} with LLM-based reflection")
             return True
-            
+
         except Exception as e:
             logger.error(f"Error initializing AgentMemoryCompressor: {e}", exc_info=True)
             return False
@@ -246,7 +246,7 @@ class CompressionEngineComponent(Component):
         except Exception as e:
             logger.warning(f"Error accessing LLM provider: {e}")
             return None
-    
+
     async def shutdown(self) -> bool:
         """Gracefully shutdown the compression engine and storage."""
         try:
@@ -255,7 +255,7 @@ class CompressionEngineComponent(Component):
                 logger.info(f"Shutting down AgentMemoryCompressor for agent {self._agent_name}")
                 await self._memory_compressor.cleanup()
                 self._memory_compressor = None
-            
+
             if self._storage:
                 logger.info(f"Shutting down storage backend for CompressionEngine {self.id}")
                 await self._storage.shutdown()
@@ -263,46 +263,46 @@ class CompressionEngineComponent(Component):
         except Exception as e:
             logger.error(f"Error during CompressionEngine shutdown: {e}", exc_info=True)
             return False
-    
+
     async def get_memory_context(self) -> List[LLMMessage]:
         """
         Placeholder for memory context retrieval.
-        
+
         This will be replaced with MemoryCompressor integration in Phase 1.
         For now, returns empty to ensure no errors during Phase 2 cleanup.
-        
+
         Returns:
             Empty list of LLMMessage objects (no memory context available)
         """
         logger.debug(f"CompressionEngine get_memory_context called - returning empty (MemoryCompressor not yet integrated)")
         return []
-    
+
     def _extract_context_key_info(self, context: str) -> str:
         """
         Extract key information from HUD context without storing the full redundant content.
-        
+
         This helps preserve what's important about each frame without storing repetitive message lists.
-        
+
         Args:
             context: Full HUD context string
-            
+
         Returns:
             A summary of key information from the context
         """
         if not context:
             return "Empty context"
-        
+
         try:
             # Look for new messages or changes (this is a simple heuristic)
             lines = context.split('\n')
-            
+
             # Count messages
             message_lines = [line for line in lines if '<sender>' in line and '<message>' in line]
             message_count = len(message_lines)
-            
+
             # Look for recent activity (last few messages)
             recent_messages = message_lines[-3:] if message_lines else []
-            
+
             # Extract sender names
             senders = set()
             for line in recent_messages:
@@ -311,27 +311,27 @@ class CompressionEngineComponent(Component):
                     sender_end = line.find('</sender>')
                     if sender_end > sender_start:
                         senders.add(line[sender_start:sender_end])
-            
+
             # Create summary
             if recent_messages:
                 sender_list = ', '.join(sorted(senders)) if senders else "unknown senders"
                 return f"Context with {message_count} messages, recent activity from: {sender_list}"
             else:
                 return f"Context with {message_count} messages"
-                
+
         except Exception as e:
             logger.warning(f"Error extracting context key info: {e}")
             return f"Context ({len(context)} chars)"
-    
+
     async def _store_interaction_messages(self, chain_data: Dict[str, Any], context_summary: str) -> None:
         """
         Store the interaction as messages for potential recompression.
-        
+
         NEW: Store interaction-focused messages instead of full context repetition.
         """
         try:
             messages = []
-            
+
             # User message (context summary instead of full context)
             if context_summary:
                 messages.append({
@@ -340,29 +340,29 @@ class CompressionEngineComponent(Component):
                     "timestamp": datetime.now().isoformat(),
                     "source": "interaction_summary"
                 })
-            
+
             # Assistant response
             agent_response = chain_data.get("agent_response")
             if agent_response:
                 messages.append({
-                    "role": "assistant", 
+                    "role": "assistant",
                     "content": agent_response,
                     "timestamp": datetime.now().isoformat(),
                     "tool_calls": chain_data.get("tool_calls", []),
                     "tool_results": chain_data.get("tool_results", [])
                 })
-            
+
             # Load existing raw messages and append new ones
             existing_messages = await self._storage.load_raw_messages(self._conversation_id)
             all_messages = existing_messages + messages
-            
+
             # Store updated message list
             await self._storage.store_raw_messages(self._conversation_id, all_messages)
             logger.debug(f"Stored interaction messages (total: {len(all_messages)})")
-            
+
         except Exception as e:
             logger.error(f"Error storing interaction messages: {e}", exc_info=True)
-    
+
     async def get_memory_stats(self) -> Dict[str, Any]:
         """Get statistics about stored memory."""
         try:
@@ -374,7 +374,7 @@ class CompressionEngineComponent(Component):
                 except Exception as stats_err:
                     logger.warning(f"Error getting AgentMemoryCompressor stats: {stats_err}")
                     memory_compressor_stats = {"error": str(stats_err)}
-            
+
             return {
                 "agent_name": self._agent_name,
                 "conversation_id": self._conversation_id,
@@ -390,32 +390,32 @@ class CompressionEngineComponent(Component):
                 "agent_name": self._agent_name,
                 "phase": "3_integration_error"
             }
-    
+
     async def clear_memory(self) -> bool:
         """Clear all stored memory. Use with caution."""
         # Phase 2.2 cleanup: No memory interactions to clear
         logger.info(f"CompressionEngine clear_memory called - no memory to clear during Phase 2 cleanup (MemoryCompressor not yet integrated)")
         return True
-    
+
     # Future compression methods (placeholder for now)
     async def enable_compression(self, strategy: str = "simple") -> bool:
         """Enable context compression (future feature)."""
         logger.info(f"Compression not yet implemented. Strategy '{strategy}' noted for future implementation.")
         self._compression_enabled = False  # Will be True when implemented
         return False
-    
+
     async def compress_older_interactions(self, older_than_hours: int = 24) -> int:
         """Compress interactions older than specified hours (future feature)."""
         logger.info(f"Compression not yet implemented. Would compress interactions older than {older_than_hours} hours.")
         return 0
-    
+
     # NEW: Conversation management methods
-    
+
     async def store_conversation_snapshot(self, conversation_data: Dict[str, Any]) -> bool:
         """Store a complete conversation snapshot in Typingcloud format."""
         if not await self._ensure_storage_ready() or not self._conversation_id:
             return False
-        
+
         try:
             success = await self._storage.store_conversation(self._conversation_id, conversation_data)
             if success:
@@ -424,23 +424,23 @@ class CompressionEngineComponent(Component):
         except Exception as e:
             logger.error(f"Error storing conversation snapshot: {e}", exc_info=True)
             return False
-    
+
     async def load_conversation_snapshot(self) -> Optional[Dict[str, Any]]:
         """Load the stored conversation snapshot."""
         if not await self._ensure_storage_ready() or not self._conversation_id:
             return None
-        
+
         try:
             return await self._storage.load_conversation(self._conversation_id)
         except Exception as e:
             logger.error(f"Error loading conversation snapshot: {e}", exc_info=True)
             return None
-    
+
     async def store_memory_formation(self, memory_id: str, memory_data: Dict[str, Any]) -> bool:
         """Store a compressed memory formation sequence."""
         if not await self._ensure_storage_ready() or not self._conversation_id:
             return False
-        
+
         try:
             success = await self._storage.store_memory(self._conversation_id, memory_id, memory_data)
             if success:
@@ -449,12 +449,12 @@ class CompressionEngineComponent(Component):
         except Exception as e:
             logger.error(f"Error storing memory formation: {e}", exc_info=True)
             return False
-    
+
     async def get_stored_memories(self) -> List[Dict[str, Any]]:
         """Get all stored memory formations for this conversation."""
         if not await self._ensure_storage_ready() or not self._conversation_id:
             return []
-        
+
         try:
             return await self._storage.load_memories(self._conversation_id)
         except Exception as e:
@@ -464,7 +464,7 @@ class CompressionEngineComponent(Component):
     async def get_memory_data(self) -> Dict[str, Any]:
         """
         Get structured memory data in VEIL-like format for HUD rendering.
-        
+
         Returns:
             Clean VEIL-like structure for HUD rendering
         """
@@ -486,9 +486,9 @@ class CompressionEngineComponent(Component):
                     "memory_compressor_available": bool(self._memory_compressor)
                 }
             }
-            
+
             return memory_data
-            
+
         except Exception as e:
             logger.error(f"Error generating memory data: {e}", exc_info=True)
             return {
@@ -520,26 +520,26 @@ class CompressionEngineComponent(Component):
                 "interaction_count": 0,
                 "summary": "No previous interactions to summarize."
             }
-        
+
         # Group interactions by type/context
         interaction_summaries = []
         total_interactions = len(self._memory_interactions)
-        
+
         # For now, create a simple summary
         # TODO: More sophisticated grouping and summarization
         recent_interactions = self._memory_interactions[-3:] if len(self._memory_interactions) > 3 else self._memory_interactions
-        
+
         for i, interaction in enumerate(recent_interactions):
             context_summary = interaction.get("context_summary", "Unknown context")
             tool_count = len(interaction.get("tool_calls", []))
-            
+
             interaction_summaries.append({
                 "interaction_index": total_interactions - len(recent_interactions) + i + 1,
                 "summary": context_summary,
                 "tool_calls_made": tool_count,
                 "timestamp": interaction.get("timestamp", "Unknown")
             })
-        
+
         return {
             "interaction_count": total_interactions,
             "showing_recent": len(recent_interactions),
@@ -551,9 +551,9 @@ class CompressionEngineComponent(Component):
         """Get the latest reasoning chain for the current conversation."""
         if not self._memory_interactions:
             return None
-            
+
         latest_interaction = self._memory_interactions[-1]
-        
+
         return {
             "has_reasoning": True,
             "timestamp": latest_interaction.get("timestamp"),
@@ -565,29 +565,29 @@ class CompressionEngineComponent(Component):
 
     # NEW: VEIL Processing Methods for Unified Rendering Pipeline
 
-    async def process_veil_with_compression(self, 
-                                          full_veil: Dict[str, Any], 
+    async def process_veil_with_compression(self,
+                                          full_veil: Dict[str, Any],
                                           focus_context: Optional[Dict[str, Any]] = None,
                                           memory_data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         NEW: Process full VEIL by compressing unfocused content while preserving focused content.
-        
+
         This creates a unified rendering pipeline where:
         - Focused element content is preserved completely
         - Unfocused container children are compressed to <content_memory> summaries
         - Tool availability and metadata are maintained on compressed elements
         - Memory context is integrated as needed
-        
+
         Args:
             full_veil: The complete VEIL structure from SpaceVeilProducer
             focus_context: Optional focus context with focus_element_id
             memory_data: Optional memory data for integration
-            
+
         Returns:
             Processed VEIL ready for unified HUD rendering
         """
         focus_element_id = focus_context.get('focus_element_id') if focus_context else None
-        
+
         with tracer.start_as_current_span("compression_engine.process_veil", attributes={
             "veil.focus_element_id": focus_element_id or "none",
             "veil.has_memory_data": bool(memory_data)
@@ -596,7 +596,7 @@ class CompressionEngineComponent(Component):
                 # Add the full VEIL snapshot as a span event
                 # We use an event because the VEIL can be very large
                 span.add_event(
-                    "VEIL Snapshot", 
+                    "VEIL Snapshot",
                     attributes={"veil.snapshot.json": json.dumps(full_veil, default=str)}
                 )
 
@@ -604,18 +604,18 @@ class CompressionEngineComponent(Component):
                     logger.warning(f"CompressionEngine received empty VEIL for processing")
                     span.set_attribute("veil.status", "empty_veil")
                     return full_veil
-                
+
                 if focus_element_id:
                     logger.info(f"Processing VEIL with compression, focusing on element: {focus_element_id}")
                     processed_veil = await self._process_focused_veil(full_veil, focus_element_id, memory_data)
                 else:
                     logger.info(f"Processing VEIL with compression, no focus (full context)")
                     processed_veil = await self._process_full_veil_with_memory(full_veil, memory_data)
-                
+
                 logger.debug(f"VEIL processing complete: preserved structure with compression applied")
                 span.set_status(trace.Status(trace.StatusCode.OK))
                 return processed_veil
-                
+
             except Exception as e:
                 logger.error(f"Error processing VEIL with compression: {e}", exc_info=True)
                 span.record_exception(e)
@@ -623,18 +623,18 @@ class CompressionEngineComponent(Component):
                 # Fallback to original VEIL
                 return full_veil
 
-    async def _process_focused_veil(self, 
-                                  full_veil: Dict[str, Any], 
+    async def _process_focused_veil(self,
+                                  full_veil: Dict[str, Any],
                                   focus_element_id: str,
                                   memory_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         """
         Process VEIL for focused rendering: preserve focused element, compress others.
-        
+
         Args:
             full_veil: Complete VEIL structure
             focus_element_id: ID of element to focus on
             memory_data: Memory context data
-            
+
         Returns:
             Processed VEIL with focused content preserved and unfocused content compressed
         """
@@ -642,30 +642,30 @@ class CompressionEngineComponent(Component):
             # Create a deep copy to avoid modifying the original
             import copy
             processed_veil = copy.deepcopy(full_veil)
-            
+
             # Inject memory context at the top level if provided
             if memory_data:
                 processed_veil = await self._inject_memory_context(processed_veil, memory_data)
-            
+
             # Apply compression to unfocused containers
             await self._compress_unfocused_containers(processed_veil, focus_element_id)
-            
+
             return processed_veil
-            
+
         except Exception as e:
             logger.error(f"Error processing focused VEIL: {e}", exc_info=True)
             return full_veil
 
-    async def _process_full_veil_with_memory(self, 
+    async def _process_full_veil_with_memory(self,
                                            full_veil: Dict[str, Any],
                                            memory_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         """
         Process VEIL for full rendering with memory integration but no compression.
-        
+
         Args:
             full_veil: Complete VEIL structure
             memory_data: Memory context data
-            
+
         Returns:
             Processed VEIL with memory integrated but minimal compression
         """
@@ -673,33 +673,33 @@ class CompressionEngineComponent(Component):
             if not memory_data:
                 # No memory to integrate, return original VEIL
                 return full_veil
-            
+
             # Create a deep copy to avoid modifying the original
             import copy
             processed_veil = copy.deepcopy(full_veil)
-            
+
             # Inject memory context
             processed_veil = await self._inject_memory_context(processed_veil, memory_data)
-            
+
             return processed_veil
-            
+
         except Exception as e:
             logger.error(f"Error processing full VEIL with memory: {e}", exc_info=True)
             return full_veil
 
-    async def _inject_memory_context(self, 
-                                   veil_root: Dict[str, Any], 
+    async def _inject_memory_context(self,
+                                   veil_root: Dict[str, Any],
                                    memory_data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Inject memory context into VEIL structure as additional nodes.
-        
+
         SIMPLIFIED: Only inject agent workspace info at top level.
         Element-specific memories are now handled within containers by _compress_container_children().
-        
+
         Args:
             veil_root: Root VEIL node to modify
             memory_data: Memory data to inject
-            
+
         Returns:
             Modified VEIL with memory context injected
         """
@@ -709,7 +709,7 @@ class CompressionEngineComponent(Component):
             if agent_info:
                 workspace_node = {
                     "veil_id": f"memory_workspace_{self.id}",
-                    "node_type": "memory_context", 
+                    "node_type": "memory_context",
                     "properties": {
                         "structural_role": "memory_section",
                         "content_nature": "agent_workspace",
@@ -720,28 +720,28 @@ class CompressionEngineComponent(Component):
                     },
                     "children": []
                 }
-                
+
                 # Inject only workspace info at top level
                 children = veil_root.get('children', [])
                 veil_root['children'] = [workspace_node] + children
                 logger.debug(f"Injected agent workspace memory context into VEIL")
-            
+
             return veil_root
-            
+
         except Exception as e:
             logger.error(f"Error injecting memory context: {e}", exc_info=True)
             return veil_root
 
-    async def _compress_unfocused_containers(self, 
-                                           veil_node: Dict[str, Any], 
+    async def _compress_unfocused_containers(self,
+                                           veil_node: Dict[str, Any],
                                            focus_element_id: str) -> None:
         """
         Recursively compress unfocused containers while preserving focused content and tool metadata.
-        
+
         ENHANCED: Now passes focus context to enable focused vs unfocused compression logic.
         This modifies the VEIL in-place by replacing unfocused container children with
         <content_memory> summaries while preserving tool availability information.
-        
+
         Args:
             veil_node: Current VEIL node to process
             focus_element_id: ID of the element to preserve (not compress)
@@ -750,52 +750,52 @@ class CompressionEngineComponent(Component):
             node_props = veil_node.get('properties', {})
             element_id = node_props.get('element_id')
             structural_role = node_props.get('structural_role')
-            
+
             # If this is a container for the focused element, preserve it completely
             if element_id == focus_element_id:
                 logger.debug(f"Preserving focused element container: {element_id}")
                 return
-            
+
             # Check if this container contains the focused element as a child
             # If so, recurse to children instead of compressing this container
             children = veil_node.get('children', [])
             contains_focused_element = any(
-                child.get('properties', {}).get('element_id') == focus_element_id 
+                child.get('properties', {}).get('element_id') == focus_element_id
                 for child in children
             )
-            
+
             if contains_focused_element:
                 logger.debug(f"Container {element_id} contains focused element {focus_element_id}, recursing to children")
                 # Recurse to children - some will be compressed, focused one will be preserved
                 for child in children:
                     await self._compress_unfocused_containers(child, focus_element_id)
                 return
-            
+
             # If this is a container but NOT focused and does NOT contain focused element, compress its children
             if structural_role == "container" and element_id and element_id != focus_element_id:
                 logger.debug(f"Compressing unfocused container: {element_id}")
                 # NEW: Pass focus context to compression logic
                 await self._compress_container_children(veil_node, element_id, focus_element_id)
                 return
-            
+
             # For non-container nodes, still recurse to children
             for child in children:
                 await self._compress_unfocused_containers(child, focus_element_id)
-                
+
         except Exception as e:
             logger.error(f"Error compressing unfocused containers: {e}", exc_info=True)
 
     async def _compress_container_children(self, container_node: Dict[str, Any], element_id: str, focus_element_id: str) -> None:
         """
         Compress a container's children using AgentMemoryCompressor for agent-driven memory formation.
-        
+
         ENHANCED: Now implements focus-aware compression with different limits:
         - Focused elements: 50k fresh + 20k memories (70k total)
         - Unfocused elements: 4k total (strict compression)
-        
+
         Phase 3: This uses the agent's LLM-based reflection instead of simple content counting.
         NEW: Uses just-in-time content change detection via flat VEIL cache comparison.
-        
+
         Args:
             container_node: The container node to compress
             element_id: ID of the element this container represents
@@ -806,7 +806,7 @@ class CompressionEngineComponent(Component):
             element_name = props.get('element_name', element_id)
             available_tools = props.get('available_tools', [])
             children = container_node.get('children', [])
-            
+
             # NEW: 1k token threshold check - don't compress small content
             total_tokens = self._calculate_children_tokens(children)
             if total_tokens < self.MIN_COMPRESSION_THRESHOLD:
@@ -816,24 +816,24 @@ class CompressionEngineComponent(Component):
                     container_node['properties']['available_tools'] = available_tools
                     container_node['properties']['tools_available_despite_preservation'] = True
                 return
-            
+
             # NEW: Determine if this element is focused
             is_focused = (element_id == focus_element_id)
-            
+
             if is_focused:
                 logger.debug(f"Applying focused compression for element {element_id}")
                 await self._apply_focused_compression(container_node, element_id, children, element_name, available_tools)
             else:
                 logger.debug(f"Applying unfocused compression for element {element_id}")
                 await self._apply_unfocused_compression(container_node, element_id, children, element_name, available_tools)
-                
+
         except Exception as e:
             logger.error(f"Error compressing container children: {e}", exc_info=True)
 
     async def _apply_focused_compression(self, container_node: Dict[str, Any], element_id: str, children: List[Dict[str, Any]], element_name: str, available_tools: List[str]) -> None:
         """
         Apply focused compression with lax limits for focused elements.
-        
+
         NEW: Enhanced with background compression support for better performance.
         For focused elements: 50k fresh content + 20k memories = 70k total
         """
@@ -843,13 +843,13 @@ class CompressionEngineComponent(Component):
                 memory_summary = "Empty conversation - no content to remember"
                 compression_approach = "empty_container_focused"
                 logger.debug(f"Empty focused container {element_id}: no children to compress")
-                
+
                 memory_node = {
                     "veil_id": f"compressed_{element_id}_{self.id}",
                     "node_type": "content_memory",
                     "properties": {
                         "structural_role": "compressed_content",
-                        "content_nature": "content_memory", 
+                        "content_nature": "content_memory",
                         "original_element_id": element_id,
                         "memory_summary": memory_summary,
                         "original_child_count": 0,
@@ -860,16 +860,16 @@ class CompressionEngineComponent(Component):
                 }
                 container_node['children'] = [memory_node]
                 return
-            
+
             # NEW Phase 2: Separate memories from fresh content for rolling compression
             existing_memories, fresh_content = self._separate_memories_and_content(children)
-            
+
             # Calculate token counts
             memory_tokens = self._calculate_memory_tokens(existing_memories)
             fresh_tokens = self._calculate_children_tokens(fresh_content)
-            
+
             logger.debug(f"Focused element {element_id}: {fresh_tokens} fresh tokens, {memory_tokens} memory tokens (limits: {self.FOCUSED_FRESH_LIMIT} fresh, {self.FOCUSED_MEMORY_LIMIT} memory)")
-            
+
             # Check if we're within limits
             needs_fresh_compression = fresh_tokens > self.FOCUSED_FRESH_LIMIT
             needs_memory_compression = memory_tokens > self.FOCUSED_MEMORY_LIMIT
@@ -878,13 +878,13 @@ class CompressionEngineComponent(Component):
                 # Within limits, preserve everything as-is
                 logger.debug(f"Focused element {element_id} within limits, preserving all content")
                 container_node['children'] = existing_memories + fresh_content
-                
+
                 # Ensure tool information is preserved
                 if available_tools:
                     container_node['properties']['available_tools'] = available_tools
                     container_node['properties']['tools_available_despite_preservation'] = True
                 return
-            
+
             # ENHANCED: Continuous rolling compression approach with background support
             final_memories = existing_memories.copy()
             final_content = fresh_content.copy()
@@ -909,20 +909,20 @@ class CompressionEngineComponent(Component):
                 final_memories = await self._recompress_excess_memories(
                     element_id, element_name, final_memories
                 )
-            
+
             # Set final children: memories + preserved fresh content
             container_node['children'] = final_memories + final_content
-            
+
             # Ensure tool information is preserved
             if available_tools:
                 container_node['properties']['available_tools'] = available_tools
                 container_node['properties']['tools_available_despite_compression'] = True
-            
+
             final_memory_tokens = self._calculate_memory_tokens(final_memories)
             final_fresh_tokens = self._calculate_children_tokens(final_content)
-            
+
             logger.info(f"Rolling compression complete for {element_id}: {final_fresh_tokens} fresh + {final_memory_tokens} memory = {final_fresh_tokens + final_memory_tokens} total tokens")
-            
+
         except Exception as e:
             logger.error(f"Error applying focused compression: {e}", exc_info=True)
             # Fallback to simple compression with background support
@@ -934,7 +934,7 @@ class CompressionEngineComponent(Component):
                         raw_veil_nodes=children,
                         token_limit=self.FOCUSED_FRESH_LIMIT + self.FOCUSED_MEMORY_LIMIT  # Full focused limit
                     )
-                    
+
                     if result_node:
                         result_props = result_node.get("properties", {})
                         memory_summary = result_props.get("memory_summary", f"Rolling compression failed: {len(children)} items from {element_name}")
@@ -949,13 +949,13 @@ class CompressionEngineComponent(Component):
             else:
                 memory_summary = f"Rolling compression failed: {len(children)} items from {element_name}"
                 compression_approach = "rolling_compression_fallback"
-            
+
             memory_node = {
                 "veil_id": f"compressed_{element_id}_{self.id}",
                 "node_type": "content_memory",
                 "properties": {
                     "structural_role": "compressed_content",
-                    "content_nature": "content_memory", 
+                    "content_nature": "content_memory",
                     "original_element_id": element_id,
                     "memory_summary": memory_summary,
                     "original_child_count": len(children),
@@ -969,7 +969,7 @@ class CompressionEngineComponent(Component):
     async def _apply_unfocused_compression(self, container_node: Dict[str, Any], element_id: str, children: List[Dict[str, Any]], element_name: str, available_tools: List[str]) -> None:
         """
         Apply unfocused compression with strict limits for unfocused elements.
-        
+
         NEW: Now uses background compression with intelligent fallbacks to prevent main thread blocking.
         For unfocused elements: 4k total (everything compressed or trimmed fresh content)
         """
@@ -982,31 +982,31 @@ class CompressionEngineComponent(Component):
             elif self._memory_compressor:
                 # NEW: Use get_memory_or_fallback for asynchronous compression strategy
                 logger.debug(f"Using asynchronous compression strategy for unfocused {element_id} with {len(children)} children")
-                
+
                 # Get memory or trimmed fresh content (non-blocking)
                 result_node = await self._memory_compressor.get_memory_or_fallback(
                     element_ids=[element_id],
                     raw_veil_nodes=children,
                     token_limit=self.UNFOCUSED_TOTAL_LIMIT  # 4k tokens for unfocused
                 )
-                
+
                 if result_node:
                     # Check what type of result we got
                     node_type = result_node.get("node_type", "")
                     result_props = result_node.get("properties", {})
-                    
+
                     if node_type == "memorized_content":
                         # We got a completed memory
                         memory_summary = result_props.get("memory_summary", "Memory content")
                         compression_approach = "agent_memory_compressor_unfocused_async"
                         logger.debug(f"Using completed memory for unfocused {element_id}")
-                    
+
                     elif node_type in ["fresh_content", "trimmed_fresh_content"]:
                         # We got fresh content fallback (compression running in background)
                         is_trimmed = result_props.get("is_trimmed", False)
                         trimmed_count = result_props.get("trimmed_node_count", len(children))
                         original_count = result_props.get("original_node_count", len(children))
-                        
+
                         if is_trimmed:
                             memory_summary = f"Recent {trimmed_count} of {original_count} items (compression in progress)"
                             compression_approach = "trimmed_fresh_content_unfocused_async"
@@ -1015,24 +1015,24 @@ class CompressionEngineComponent(Component):
                             memory_summary = f"All {len(children)} recent items (compression in progress)"
                             compression_approach = "fresh_content_unfocused_async"
                             logger.debug(f"Using full fresh content for unfocused {element_id}")
-                        
+
                         # For fresh content, we need to replace the container children with the result
                         container_node['children'] = result_node.get("children", children)
-                        
+
                         # Ensure tool information is preserved
                         if available_tools:
                             container_node['properties']['available_tools'] = available_tools
                             container_node['properties']['tools_available_despite_compression'] = True
-                        
+
                         logger.debug(f"Applied fresh content fallback to unfocused container {element_id}")
                         return  # Early return - content already set
-                    
+
                     elif node_type == "compression_placeholder":
                         # We got a placeholder (compression starting)
                         memory_summary = result_props.get("memory_summary", "⏳ Processing conversation memory...")
                         compression_approach = "compression_placeholder_unfocused_async"
                         logger.debug(f"Using compression placeholder for unfocused {element_id}")
-                    
+
                     else:
                         # Unknown result type, extract summary
                         memory_summary = result_props.get("memory_summary", f"Content from {element_id}")
@@ -1047,14 +1047,14 @@ class CompressionEngineComponent(Component):
                 logger.debug(f"AgentMemoryCompressor not available, using simple summary for unfocused {element_id}")
                 memory_summary = await self._generate_content_summary(children, element_id)
                 compression_approach = "simple_summary_fallback_unfocused"
-            
+
             # Create content memory node (for memory results and placeholders)
             memory_node = {
                 "veil_id": f"compressed_{element_id}_{self.id}",
                 "node_type": "content_memory",
                 "properties": {
                     "structural_role": "compressed_content",
-                    "content_nature": "content_memory", 
+                    "content_nature": "content_memory",
                     "original_element_id": element_id,
                     "memory_summary": memory_summary,
                     "original_child_count": len(children),
@@ -1066,32 +1066,32 @@ class CompressionEngineComponent(Component):
                 },
                 "children": []
             }
-            
+
             # Replace children with the memory summary but preserve container metadata
             container_node['children'] = [memory_node]
-            
+
             # Ensure tool information is preserved on the container
             if available_tools:
                 container_node['properties']['available_tools'] = available_tools
                 container_node['properties']['tools_available_despite_compression'] = True
-            
+
             logger.debug(f"Applied unfocused compression to container {element_id}: {len(children)} children → {compression_approach}")
-            
+
         except Exception as e:
             logger.error(f"Error applying unfocused compression: {e}", exc_info=True)
 
-    async def _has_content_changed_since_compression(self, 
-                                                   element_id: str, 
-                                                   memory_id: str, 
+    async def _has_content_changed_since_compression(self,
+                                                   element_id: str,
+                                                   memory_id: str,
                                                    current_children: List[Dict[str, Any]]) -> bool:
         """
         Check if content has changed since the last compression by comparing content fingerprints.
-        
+
         Args:
             element_id: ID of the element being checked
             memory_id: ID of the existing memory
             current_children: Current VEIL children to compare
-            
+
         Returns:
             True if content has changed and recompression is needed, False otherwise
         """
@@ -1101,55 +1101,55 @@ class CompressionEngineComponent(Component):
             if not existing_memory:
                 logger.warning(f"Could not load memory {memory_id} for content comparison")
                 return True  # Assume changed if we can't load the memory
-            
+
             # Get stored content fingerprint
             memory_metadata = existing_memory.get("metadata", {})
             stored_fingerprint = memory_metadata.get("content_fingerprint")
-            
+
             if not stored_fingerprint:
                 logger.debug(f"No content fingerprint stored for memory {memory_id}, assuming content changed")
                 return True
-            
+
             # Calculate current content fingerprint
             current_fingerprint = self._calculate_content_fingerprint(current_children)
-            
+
             # Compare fingerprints
             content_changed = stored_fingerprint != current_fingerprint
-            
+
             if content_changed:
                 logger.debug(f"Content fingerprint changed for {element_id}: {stored_fingerprint[:16]}... → {current_fingerprint[:16]}...")
             else:
                 logger.debug(f"Content fingerprint unchanged for {element_id}: {current_fingerprint[:16]}...")
-            
+
             return content_changed
-            
+
         except Exception as e:
             logger.error(f"Error checking content changes for {element_id}: {e}", exc_info=True)
             return True  # Assume changed on error to ensure fresh compression
-    
+
     def _calculate_content_fingerprint(self, children: List[Dict[str, Any]]) -> str:
         """
         Calculate a content fingerprint for VEIL children to detect changes.
-        
+
         ENHANCED: Now includes attachment content hashes for multimodal change detection.
-        
+
         Args:
             children: List of VEIL child nodes
-            
+
         Returns:
             Content fingerprint string
         """
         try:
             import hashlib
             import json
-            
+
             # Extract key content for fingerprinting
             content_items = []
-            
+
             for child in children:
                 props = child.get("properties", {})
                 content_nature = props.get("content_nature", "")
-                
+
                 if content_nature == "chat_message":
                     # For chat messages, include sender, text, and timestamp
                     message_content = {
@@ -1160,7 +1160,7 @@ class CompressionEngineComponent(Component):
                         "reactions": props.get("reactions", {}),  # Include reactions for change detection
                         "message_status": props.get("message_status", "received")  # Include status changes
                     }
-                    
+
                     # NEW: Include attachment metadata in fingerprint
                     attachments = props.get("attachment_metadata", [])
                     if attachments:
@@ -1172,12 +1172,12 @@ class CompressionEngineComponent(Component):
                             }
                             for att in attachments
                         ]
-                    
+
                     # NEW: Include attachment content hashes from child nodes
                     attachment_content_hashes = self._get_attachment_content_hashes(child)
                     if attachment_content_hashes:
                         message_content["attachment_content_hashes"] = attachment_content_hashes
-                    
+
                     content_items.append(message_content)
                 else:
                     # For other content types, include basic properties
@@ -1187,41 +1187,41 @@ class CompressionEngineComponent(Component):
                         "content_nature": content_nature
                     }
                     content_items.append(generic_content)
-            
+
             # Create deterministic JSON representation
             content_json = json.dumps(content_items, sort_keys=True, separators=(',', ':'))
-            
+
             # Generate SHA-256 hash
             fingerprint = hashlib.sha256(content_json.encode('utf-8')).hexdigest()
-            
+
             return fingerprint
-            
+
         except Exception as e:
             logger.error(f"Error calculating content fingerprint: {e}", exc_info=True)
             # Return timestamp-based fallback
             return f"error_fallback_{datetime.now().isoformat()}"
-    
+
     def _get_attachment_content_hashes(self, message_node: Dict[str, Any]) -> Dict[str, str]:
         """
         NEW: Get content hashes for attachment children to detect content changes.
-        
+
         Args:
             message_node: VEIL message node with potential attachment children
-            
+
         Returns:
             Dictionary mapping attachment_id to content hash
         """
         try:
             import hashlib
-            
+
             attachment_hashes = {}
             children = message_node.get("children", [])
-            
+
             for child in children:
                 if child.get("node_type") == "attachment_content_item":
                     child_props = child.get("properties", {})
                     attachment_id = child_props.get("attachment_id")
-                    
+
                     if attachment_id:
                         # Create a content hash based on available properties
                         # This is a placeholder - in a real implementation, we might
@@ -1231,52 +1231,52 @@ class CompressionEngineComponent(Component):
                             "content_nature": child_props.get("content_nature", ""),
                             "content_available": child_props.get("content_available", False)
                         }
-                        
+
                         # Generate hash of content indicators
                         content_string = json.dumps(content_indicators, sort_keys=True)
                         content_hash = hashlib.sha256(content_string.encode('utf-8')).hexdigest()[:16]  # Short hash
-                        
+
                         attachment_hashes[attachment_id] = content_hash
-            
+
             return attachment_hashes
-            
+
         except Exception as e:
             logger.error(f"Error getting attachment content hashes: {e}", exc_info=True)
             return {}
-    
-    async def _create_new_agent_memory(self, 
-                                     element_id: str, 
-                                     element_name: str, 
-                                     available_tools: List[str], 
+
+    async def _create_new_agent_memory(self,
+                                     element_id: str,
+                                     element_name: str,
+                                     available_tools: List[str],
                                      children: List[Dict[str, Any]],
                                      is_recompression: bool = False,
                                      is_focused: bool = False) -> tuple[str, str]:
         """
         Create a new agent memory using AgentMemoryCompressor.
-        
+
         ENHANCED: Now supports focused vs unfocused compression context.
         NEW: Passes existing memory context directly from compression pipeline.
-        
+
         Returns:
             Tuple of (memory_summary, compression_approach)
         """
         try:
             element_ids = [element_id]
-            
+
             # NEW: Extract existing memories from children for context
             existing_memories, fresh_content = self._separate_memories_and_content(children)
             existing_memory_summaries = []
-            
+
             for memory_node in existing_memories:
                 memory_props = memory_node.get("properties", {})
                 memory_summary = memory_props.get("memory_summary", "")
                 if memory_summary:
                     existing_memory_summaries.append(memory_summary)
-            
+
             # NEW: Add focus context to compression metadata
             focus_type = "focused" if is_focused else "unfocused"
             action_type = "recompression" if is_recompression else "compression"
-            
+
             compression_context = {
                 "element_id": element_id,
                 "element_name": element_name,
@@ -1290,30 +1290,30 @@ class CompressionEngineComponent(Component):
                 "existing_memory_context": existing_memory_summaries,
                 "existing_memory_count": len(existing_memories)
             }
-            
+
             # Pass only fresh content for compression, with existing memories as context
             memorized_veil_node = await self._memory_compressor.compress(
                 raw_veil_nodes=fresh_content,  # Only fresh content to compress
                 element_ids=element_ids,
                 compression_context=compression_context  # Existing memories included as context
             )
-            
+
             if memorized_veil_node:
                 memory_summary = memorized_veil_node.get("properties", {}).get("memory_summary", "Agent memory formation failed")
-                
+
                 # NEW: Generate focus-aware compression approach labels
                 if is_recompression:
                     compression_approach = f"agent_memory_recompressor_{focus_type}"
                 else:
                     compression_approach = f"agent_memory_compressor_{focus_type}"
-                
+
                 action = "Recompressed" if is_recompression else "Agent reflected on"
                 memory_context_info = f" (with {len(existing_memory_summaries)} memory context)" if existing_memory_summaries else ""
                 logger.info(f"{action} {focus_type} container {element_id}: {memory_summary[:100]}...{memory_context_info}")
                 return memory_summary, compression_approach
             else:
                 raise Exception("AgentMemoryCompressor returned None")
-                
+
         except Exception as compression_error:
             logger.warning(f"AgentMemoryCompressor failed for {focus_type} {element_id}: {compression_error}")
             memory_summary = await self._generate_content_summary(children, element_id)
@@ -1323,60 +1323,60 @@ class CompressionEngineComponent(Component):
     async def _generate_content_summary(self, children: List[Dict[str, Any]], element_id: str) -> str:
         """
         Generate a human-readable summary of compressed content.
-        
+
         Args:
             children: List of child VEIL nodes to summarize
             element_id: ID of the element being summarized
-            
+
         Returns:
             Human-readable content summary
         """
         try:
             if not children:
                 return "Empty conversation"
-            
+
             # Count different types of content
             message_count = 0
             last_message_preview = ""
             senders = set()
             has_attachments = False
-            
+
             for child in children:
                 child_props = child.get('properties', {})
                 content_nature = child_props.get('content_nature', '')
-                
+
                 if content_nature == "chat_message":
                     message_count += 1
                     sender = child_props.get('sender_name')
                     if sender:
                         senders.add(sender)
-                    
+
                     # Get preview of last message
                     text_content = child_props.get('text_content', '')
                     if text_content:
                         last_message_preview = text_content[:50] + ("..." if len(text_content) > 50 else "")
-                    
+
                     # Check for attachments
                     attachments = child_props.get('attachment_metadata', [])
                     if attachments:
                         has_attachments = True
-            
+
             # Build summary
             if message_count == 0:
                 return "No recent messages"
-            
+
             participants = f"{len(senders)} participants" if len(senders) > 1 else list(senders)[0] if senders else "unknown"
-            
+
             summary = f"Chat with {participants}: {message_count} messages"
-            
+
             if has_attachments:
                 summary += " (with attachments)"
-            
+
             if last_message_preview:
                 summary += f". Recent: \"{last_message_preview}\""
-            
+
             return summary
-            
+
         except Exception as e:
             logger.error(f"Error generating content summary: {e}", exc_info=True)
             return f"Content from {element_id}"
@@ -1386,128 +1386,128 @@ class CompressionEngineComponent(Component):
     def _separate_memories_and_content(self, children: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
         """
         Separate existing memories from fresh content in a list of children.
-        
+
         Args:
             children: List of VEIL child nodes
-            
+
         Returns:
             Tuple of (memories, fresh_content)
         """
         memories = []
         content = []
-        
+
         for child in children:
             node_type = child.get("node_type", "")
             if node_type in ["content_memory", "memorized_content"]:
                 memories.append(child)
             else:
                 content.append(child)
-        
+
         return memories, content
 
-    async def _compress_excess_fresh_content_async(self, element_id: str, element_name: str, available_tools: List[str], 
+    async def _compress_excess_fresh_content_async(self, element_id: str, element_name: str, available_tools: List[str],
                                                   fresh_content: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
         """
         NEW: Enhanced version of fresh content compression with background processing support.
-        
+
         This version can use background compression for non-critical chunks while maintaining
         responsive performance for focused elements.
         """
         try:
             if not fresh_content:
                 return [], []
-            
+
             total_fresh_tokens = self._calculate_children_tokens(fresh_content)
             excess_tokens = total_fresh_tokens - self.FOCUSED_FRESH_LIMIT
-            
+
             if excess_tokens <= self.MIN_COMPRESSION_BATCH:
                 # Not enough excess to warrant compression (avoid micro-compressions)
                 logger.debug(f"Excess tokens ({excess_tokens}) below minimum batch size ({self.MIN_COMPRESSION_BATCH})")
                 return [], fresh_content
-            
+
             logger.info(f"Continuous rolling compression with async support: {excess_tokens} excess tokens from {element_id}")
-            
+
             new_memories = []
             remaining_content = fresh_content.copy()
-            
+
             # Continuously compress 4k chunks until within limits
             while True:
                 current_tokens = self._calculate_children_tokens(remaining_content)
                 current_excess = current_tokens - self.FOCUSED_FRESH_LIMIT
-                
+
                 if current_excess <= 0:
                     break  # Within limits now
-                
+
                 # Find 4k token boundary for next compression chunk
                 chunk_tokens = min(self.COMPRESSION_CHUNK_SIZE, current_excess + 1000)  # Add buffer
                 chunk_boundary = self._find_token_based_boundary(remaining_content, chunk_tokens)
-                
+
                 if chunk_boundary <= 0:
                     logger.warning(f"Cannot find valid token boundary for {element_id}")
                     break
-                
+
                 # Compress this chunk with background support
                 chunk_to_compress = remaining_content[:chunk_boundary]
                 remaining_content = remaining_content[chunk_boundary:]
-                
+
                 # Create memory from this chunk (can be async for non-critical chunks)
                 chunk_memory = await self._create_token_based_memory_chunk_async(
                     chunk_to_compress, element_id, element_name, available_tools, len(new_memories)
                 )
-                
+
                 if chunk_memory:
                     new_memories.append(chunk_memory)
-                
+
                 logger.debug(f"Compressed chunk {len(new_memories)}: {len(chunk_to_compress)} items → memory")
-                
+
                 # Safety check to avoid infinite loops
                 if len(new_memories) > 20:  # Max 20 compression cycles
                     logger.warning(f"Too many compression cycles for {element_id}, stopping")
                     break
-            
+
             final_fresh_tokens = self._calculate_children_tokens(remaining_content)
             total_memory_tokens = sum(self._calculate_memory_tokens([mem]) for mem in new_memories)
-            
+
             logger.info(f"Continuous rolling complete: {total_fresh_tokens} → {final_fresh_tokens} fresh tokens, created {len(new_memories)} memories ({total_memory_tokens} tokens)")
-            
+
             return new_memories, remaining_content
-            
+
         except Exception as e:
             logger.error(f"Error in async continuous rolling compression: {e}", exc_info=True)
             # Fallback: preserve everything
             return [], fresh_content
 
-    async def _create_token_based_memory_chunk_async(self, content_to_compress: List[Dict[str, Any]], element_id: str, 
+    async def _create_token_based_memory_chunk_async(self, content_to_compress: List[Dict[str, Any]], element_id: str,
                                                     element_name: str, available_tools: List[str], chunk_index: int) -> Dict[str, Any]:
         """
         NEW: Enhanced version of memory chunk creation with background compression support.
-        
+
         For focused elements, we can use background compression for older chunks
         while keeping recent chunks responsive.
         """
         try:
             if not content_to_compress:
                 return None
-            
+
             # Determine if this chunk should use background compression
             # For focused elements, we can afford some background processing for older chunks
             use_background = chunk_index > 0  # First chunk synchronous, others can be background
-            
+
             if self._memory_compressor and use_background:
                 # Use the new async compression strategy
                 chunk_element_id = f"{element_id}_chunk_{chunk_index}"
-                
+
                 result_node = await self._memory_compressor.get_memory_or_fallback(
                     element_ids=[chunk_element_id],
                     raw_veil_nodes=content_to_compress,
                     token_limit=self.COMPRESSION_CHUNK_SIZE
                 )
-                
+
                 if result_node:
                     # Convert result to memory node format
                     result_props = result_node.get("properties", {})
                     memory_summary = result_props.get("memory_summary", f"Memory chunk {chunk_index + 1}: {len(content_to_compress)} items from {element_name}")
-                    
+
                     memory_node = {
                         "veil_id": f"rolling_memory_{element_id}_{chunk_index}_{self.id}",
                         "node_type": "content_memory",
@@ -1527,18 +1527,18 @@ class CompressionEngineComponent(Component):
                         "children": []
                     }
                     return memory_node
-            
+
             # Fallback to synchronous compression or simple summary
             if self._memory_compressor:
                 memory_summary, compression_approach = await self._create_new_agent_memory(
-                    f"{element_id}_chunk_{chunk_index}", element_name, available_tools, content_to_compress, 
+                    f"{element_id}_chunk_{chunk_index}", element_name, available_tools, content_to_compress,
                     is_recompression=False, is_focused=True
                 )
             else:
                 # Fallback summary
                 memory_summary = f"Memory chunk {chunk_index + 1}: {len(content_to_compress)} items from {element_name}"
                 compression_approach = "chunk_fallback_summary"
-            
+
             # Create memory node
             memory_node = {
                 "veil_id": f"rolling_memory_{element_id}_{chunk_index}_{self.id}",
@@ -1557,80 +1557,80 @@ class CompressionEngineComponent(Component):
                 },
                 "children": []
             }
-            
+
             return memory_node
-            
+
         except Exception as e:
             logger.error(f"Error creating async token-based memory chunk: {e}", exc_info=True)
             return None
 
-    async def _recompress_excess_memories(self, element_id: str, element_name: str, 
+    async def _recompress_excess_memories(self, element_id: str, element_name: str,
                                         memories: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         ENHANCED Phase 2: Continuous memory recompression with tighter limits.
-        
+
         NEW APPROACH: Instead of waiting for 20k memory tokens, we recompress
         continuously when memory exceeds 4k tokens. This maintains tighter
         control over memory usage and better compression quality.
-        
+
         Args:
             element_id: ID of element for context
             element_name: Name of element for context
             memories: List of memory VEIL nodes
-            
+
         Returns:
             Recompressed memory list within token limits
         """
         try:
             if not memories:
                 return []
-            
+
             current_tokens = self._calculate_memory_tokens(memories)
-            
+
             if current_tokens <= self.FOCUSED_MEMORY_LIMIT:
                 return memories  # Already within limits
-            
+
             logger.info(f"Continuous memory recompression: {len(memories)} memories ({current_tokens} tokens) for {element_id}")
-            
+
             # Sort memories by timestamp (oldest first)
             sorted_memories = self._sort_memories_by_age(memories)
             final_memories = []
-            
+
             # Continuously recompress until within 4k limit
             while True:
                 current_memory_tokens = self._calculate_memory_tokens(sorted_memories)
-                
+
                 if current_memory_tokens <= self.FOCUSED_MEMORY_LIMIT:
                     final_memories = sorted_memories
                     break
-                
+
                 # Take 2 oldest memories and combine them
                 if len(sorted_memories) < 2:
                     # Can't compress further, keep what we have
                     final_memories = sorted_memories
                     break
-                
+
                 oldest_memories = sorted_memories[:2]
                 remaining_memories = sorted_memories[2:]
-                
+
                 # Create summary of the 2 oldest memories
                 summary_memory = await self._create_memory_summary(oldest_memories, element_id, element_name)
-                
+
                 # Replace the 2 oldest with 1 summary
                 sorted_memories = [summary_memory] + remaining_memories
-                
+
                 logger.debug(f"Combined 2 oldest memories into 1 summary, now {len(sorted_memories)} memories")
-                
+
                 # Safety check to avoid infinite loops
                 if len(sorted_memories) <= 1:
                     final_memories = sorted_memories
                     break
-            
+
             final_tokens = self._calculate_memory_tokens(final_memories)
             logger.info(f"Continuous memory recompression complete: {len(memories)} → {len(final_memories)} memories, {current_tokens} → {final_tokens} tokens")
-            
+
             return final_memories
-            
+
         except Exception as e:
             logger.error(f"Error in continuous memory recompression: {e}", exc_info=True)
             # Fallback: keep newest memories up to limit
@@ -1649,23 +1649,23 @@ class CompressionEngineComponent(Component):
                     except:
                         pass
                 return datetime.min  # Fallback for unparseable timestamps
-            
+
             return sorted(memories, key=get_timestamp)
-            
+
         except Exception as e:
             logger.error(f"Error sorting memories by age: {e}", exc_info=True)
             return memories  # Return unsorted if sorting fails
 
-    async def _create_memory_summary(self, memories_to_summarize: List[Dict[str, Any]], 
+    async def _create_memory_summary(self, memories_to_summarize: List[Dict[str, Any]],
                                    element_id: str, element_name: str) -> Dict[str, Any]:
         """
         Create a higher-level summary memory from multiple existing memories.
-        
+
         Args:
             memories_to_summarize: List of memory nodes to combine
             element_id: Element ID for context
             element_name: Element name for context
-            
+
         Returns:
             Single summary memory node
         """
@@ -1673,20 +1673,20 @@ class CompressionEngineComponent(Component):
             # Extract summaries from individual memories
             individual_summaries = []
             total_original_count = 0
-            
+
             for memory in memories_to_summarize:
                 props = memory.get("properties", {})
                 summary = props.get("memory_summary", "Unknown memory")
                 original_count = props.get("original_child_count", 0)
-                
+
                 individual_summaries.append(summary)
                 total_original_count += original_count
-            
+
             # Create combined summary
             if self._memory_compressor:
                 # Use LLM to create intelligent summary of summaries
                 combined_content = "\n".join([f"Memory {i+1}: {summary}" for i, summary in enumerate(individual_summaries)])
-                
+
                 # Create compression context for memory summarization
                 compression_context = {
                     "element_id": element_id,
@@ -1696,7 +1696,7 @@ class CompressionEngineComponent(Component):
                     "is_memory_summary": True,
                     "summarized_memory_count": len(memories_to_summarize)
                 }
-                
+
                 # Create a pseudo-VEIL structure for the memory content
                 pseudo_content = [{
                     "veil_id": f"memory_summary_content_{i}",
@@ -1706,25 +1706,25 @@ class CompressionEngineComponent(Component):
                         "text_content": summary
                     }
                 } for i, summary in enumerate(individual_summaries)]
-                
+
                 # Use memory compressor to create intelligent summary
                 memorized_node = await self._memory_compressor.compress(
                     raw_veil_nodes=pseudo_content,
                     element_ids=[f"{element_id}_summary"],
                     compression_context=compression_context
                 )
-                
+
                 if memorized_node:
                     summary_text = memorized_node.get("properties", {}).get("memory_summary", "Summary creation failed")
                     compression_approach = "agent_memory_recompressor_summary"
                 else:
                     raise Exception("Memory compressor failed for summary")
-                    
+
             else:
                 # Fallback: simple concatenation
                 summary_text = f"Combined memory: {len(memories_to_summarize)} older memories from {element_name}"
                 compression_approach = "simple_memory_summary"
-            
+
             # Create summary memory node
             summary_memory = {
                 "veil_id": f"summary_memory_{element_id}_{self.id}",
@@ -1743,10 +1743,10 @@ class CompressionEngineComponent(Component):
                 },
                 "children": []
             }
-            
+
             logger.info(f"Created memory summary: {len(memories_to_summarize)} memories → 1 summary")
             return summary_memory
-            
+
         except Exception as e:
             logger.error(f"Error creating memory summary: {e}", exc_info=True)
             # Fallback summary
@@ -1769,17 +1769,17 @@ class CompressionEngineComponent(Component):
     def _find_existing_total_memory(self, children: List[Dict[str, Any]], element_id: str) -> Optional[Dict[str, Any]]:
         """
         Find existing total memory for an element (for unfocused element reuse).
-        
+
         Args:
             children: List of children to check
             element_id: ID of the element being checked
-            
+
         Returns:
             Existing memory node if found, None otherwise
         """
         if not self._memory_compressor:
             return None
-        
+
         memory_id = self._memory_compressor.get_memory_for_elements([element_id])
         if memory_id:
             # Look for the memory in the children
@@ -1790,21 +1790,21 @@ class CompressionEngineComponent(Component):
                 # Also check for content_memory nodes that might reference this memory
                 if child.get("node_type") == "content_memory" and node_props.get("original_element_id") == element_id:
                     return child
-        
+
         return None
 
     def _calculate_memory_tokens(self, memory_nodes: List[Dict[str, Any]]) -> int:
         """
         Calculate total tokens in memory nodes.
-        
+
         Args:
             memory_nodes: List of memory VEIL nodes
-            
+
         Returns:
             Estimated token count
         """
         total_tokens = 0
-        
+
         for memory_node in memory_nodes:
             node_props = memory_node.get("properties", {})
             # Check for stored token count
@@ -1817,16 +1817,16 @@ class CompressionEngineComponent(Component):
                 # Rough estimate: 4 characters per token
                 estimated_tokens = len(memory_summary) // 4
                 total_tokens += estimated_tokens
-        
+
         return total_tokens
 
     def _calculate_children_tokens(self, children: List[Dict[str, Any]]) -> int:
         """
         Calculate total tokens in VEIL children.
-        
+
         Args:
             children: List of VEIL child nodes
-            
+
         Returns:
             Estimated token count
         """
@@ -1842,26 +1842,26 @@ class CompressionEngineComponent(Component):
                 props = child.get("properties", {})
                 text_content = props.get("text_content", "")
                 total_chars += len(text_content)
-            
-            # Rough estimate: 4 characters per token
-            return total_chars // 4 
 
-    def _create_trimmed_fresh_content(self, 
-                                    raw_veil_nodes: List[Dict[str, Any]], 
-                                    element_ids: List[str], 
+            # Rough estimate: 4 characters per token
+            return total_chars // 4
+
+    def _create_trimmed_fresh_content(self,
+                                    raw_veil_nodes: List[Dict[str, Any]],
+                                    element_ids: List[str],
                                     token_limit: int) -> Dict[str, Any]:
         """
         NEW: Create a trimmed version of fresh content that fits within token limits.
-        
+
         This provides immediate context while compression runs in background.
         """
         try:
             if not raw_veil_nodes:
                 return self._create_compression_placeholder("empty", element_ids, [])
-            
+
             # Calculate total tokens
             total_tokens = estimate_veil_tokens(raw_veil_nodes)
-            
+
             if total_tokens <= token_limit:
                 # Content fits within limit, return as-is but mark as fresh
                 return {
@@ -1877,11 +1877,11 @@ class CompressionEngineComponent(Component):
                     },
                     "children": raw_veil_nodes
                 }
-            
+
             # Content exceeds limit, trim to most recent content
             trimmed_nodes = []
             current_tokens = 0
-            
+
             # Process nodes in reverse order (newest first)
             for node in reversed(raw_veil_nodes):
                 node_tokens = estimate_veil_tokens([node])
@@ -1890,14 +1890,14 @@ class CompressionEngineComponent(Component):
                     current_tokens += node_tokens
                 else:
                     break
-            
+
             if not trimmed_nodes:
                 # Even single node exceeds limit, take the newest one anyway
                 trimmed_nodes = [raw_veil_nodes[-1]]
                 current_tokens = estimate_veil_tokens(trimmed_nodes)
-            
+
             logger.debug(f"Trimmed content: {len(raw_veil_nodes)} → {len(trimmed_nodes)} nodes, {total_tokens} → {current_tokens} tokens")
-            
+
             return {
                 "veil_id": f"trimmed_fresh_{element_ids[0] if element_ids else 'unknown'}",
                 "node_type": "trimmed_fresh_content",
@@ -1915,7 +1915,7 @@ class CompressionEngineComponent(Component):
                 },
                 "children": trimmed_nodes
             }
-            
+
         except Exception as e:
             logger.error(f"Error creating trimmed fresh content: {e}", exc_info=True)
             return self._create_compression_placeholder("trimming_error", element_ids, raw_veil_nodes)
@@ -1923,26 +1923,26 @@ class CompressionEngineComponent(Component):
     def _find_token_based_boundary(self, children: List[Dict[str, Any]], chunk_tokens: int) -> int:
         """
         Find where to split content for rolling compression, respecting conversation boundaries.
-        
+
         ENHANCED: Now respects message boundaries and conversation flow for better compression quality.
-        
+
         Strategy:
         1. Never split individual messages
         2. Prefer natural conversation breaks (time gaps, topic changes)
         3. Respect message groupings by same sender
         4. Fall back to message boundaries if needed
-        
+
         Args:
             children: List of fresh content nodes (should be in chronological order)
             chunk_tokens: Number of tokens we need to remove
-            
+
         Returns:
             Index where to split (content[0:boundary] gets compressed, content[boundary:] preserved)
         """
         try:
             if not children or chunk_tokens <= 0:
                 return 0
-            
+
             # If chunk_tokens is larger than all content, compress most but leave some
             total_tokens = self._calculate_children_tokens(children)
             if chunk_tokens >= total_tokens:
@@ -1951,33 +1951,33 @@ class CompressionEngineComponent(Component):
                 max_boundary = len(children) - min_preserve
                 logger.debug(f"Chunk size ({chunk_tokens}) >= total ({total_tokens}), using max boundary {max_boundary}")
                 return max_boundary
-            
+
             tokens_accumulated = 0
             best_boundary = 0
             last_conversation_break = 0
-            
+
             # Analyze message flow to find natural boundaries
             for i, content_item in enumerate(children):
                 item_tokens = self._calculate_children_tokens([content_item])
                 tokens_accumulated += item_tokens
-                
+
                 # Always update boundary to complete messages (never split mid-message)
                 boundary_candidate = i + 1
-                
+
                 # Check if this is a natural conversation break
                 is_conversation_break = self._is_natural_conversation_break(
                     children, i, content_item
                 )
-                
+
                 if is_conversation_break:
                     last_conversation_break = boundary_candidate
                     logger.debug(f"Found conversation break at index {i} ({tokens_accumulated} tokens)")
-                
+
                 # If we've accumulated enough tokens, find the best stopping point
                 if tokens_accumulated >= chunk_tokens:
                     # Prefer conversation breaks if we found one recently
                     conversation_break_distance = boundary_candidate - last_conversation_break
-                    
+
                     if last_conversation_break > 0 and conversation_break_distance <= 5:
                         # Use conversation break if it's within 5 messages of target (reduced from 10)
                         best_boundary = last_conversation_break
@@ -1986,75 +1986,75 @@ class CompressionEngineComponent(Component):
                         # Use current message boundary (complete the current message)
                         best_boundary = boundary_candidate
                         logger.debug(f"Using message boundary at {best_boundary}")
-                    
+
                     break
-            
+
             # If we didn't find enough tokens, use what we have but respect limits
             if best_boundary == 0 and len(children) > 0:
                 # Ensure we don't compress everything (leave at least 25% of content)
                 min_preserve = max(1, len(children) // 4)
                 best_boundary = min(len(children) - min_preserve, len(children) - 1)
                 logger.debug(f"Insufficient tokens for target, using fallback boundary {best_boundary}")
-            
+
             # Final safety check - ensure we don't compress everything
             min_preserve = max(1, len(children) // 4)
             max_compress = len(children) - min_preserve
             best_boundary = min(best_boundary, max_compress)
-            
+
             final_tokens = self._calculate_children_tokens(children[:best_boundary])
             logger.debug(f"Smart boundary: compress {best_boundary}/{len(children)} messages ({final_tokens} tokens)")
-            
+
             return best_boundary
-            
+
         except Exception as e:
             logger.error(f"Error finding smart token-based boundary: {e}", exc_info=True)
             # Fallback: compress half, ensuring message boundaries
             return len(children) // 2
 
-    def _is_natural_conversation_break(self, children: List[Dict[str, Any]], current_index: int, 
+    def _is_natural_conversation_break(self, children: List[Dict[str, Any]], current_index: int,
                                      current_item: Dict[str, Any]) -> bool:
         """
         Determine if there's a natural conversation break at this point.
-        
+
         Natural breaks include:
         - Time gaps between messages (>1 hour)
         - Topic changes (different keywords/context)
         - Sender changes after long messages
         - Attachment boundaries (before/after attachments)
-        
+
         Args:
             children: Full list of content items
             current_index: Index of current item being evaluated
             current_item: The current content item
-            
+
         Returns:
             True if this is a good place for a conversation break
         """
         try:
             props = current_item.get("properties", {})
             content_nature = props.get("content_nature", "")
-            
+
             # Only analyze chat messages for conversation breaks
             if content_nature != "chat_message":
                 return False
-            
+
             # Time-based breaks: look for gaps >1 hour
             time_break = self._check_time_gap_break(children, current_index)
             if time_break:
                 return True
-            
+
             # Sender-based breaks: new speaker after substantial content
             sender_break = self._check_sender_change_break(children, current_index)
             if sender_break:
                 return True
-            
+
             # Attachment boundaries: before/after attachments
             attachment_break = self._check_attachment_boundary_break(children, current_index)
             if attachment_break:
                 return True
-            
+
             return False
-            
+
         except Exception as e:
             logger.debug(f"Error checking conversation break: {e}")
             return False
@@ -2064,42 +2064,42 @@ class CompressionEngineComponent(Component):
         try:
             if current_index == 0:
                 return True  # Beginning is always a good break
-            
+
             current_props = children[current_index].get("properties", {})
             prev_props = children[current_index - 1].get("properties", {})
-            
+
             current_time = current_props.get("timestamp_iso")
             prev_time = prev_props.get("timestamp_iso")
-            
+
             if not current_time or not prev_time:
                 return False
-            
+
             # Parse timestamps and check for gaps
             from datetime import datetime, timedelta
-            
+
             try:
                 if isinstance(current_time, str):
                     current_dt = datetime.fromisoformat(current_time.replace('Z', '+00:00'))
                 else:
                     current_dt = datetime.fromtimestamp(current_time)
-                
+
                 if isinstance(prev_time, str):
                     prev_dt = datetime.fromisoformat(prev_time.replace('Z', '+00:00'))
                 else:
                     prev_dt = datetime.fromtimestamp(prev_time)
-                
+
                 time_gap = current_dt - prev_dt
-                
+
                 # Consider >1 hour as a conversation break
                 if time_gap > timedelta(hours=1):
                     logger.debug(f"Time gap break: {time_gap} between messages")
                     return True
-                    
+
             except (ValueError, TypeError):
                 pass  # Invalid timestamp format
-            
+
             return False
-            
+
         except Exception as e:
             logger.debug(f"Error checking time gap: {e}")
             return False
@@ -2109,40 +2109,40 @@ class CompressionEngineComponent(Component):
         try:
             if current_index == 0:
                 return True  # First message is always a break
-            
+
             current_props = children[current_index].get("properties", {})
             current_sender = current_props.get("sender_name", "")
-            
+
             # Check if sender actually changed
             prev_props = children[current_index - 1].get("properties", {})
             prev_sender = prev_props.get("sender_name", "")
-            
+
             if current_sender == prev_sender:
                 return False  # Same sender, not a break
-            
+
             # Look back to see how much content the previous sender had
             consecutive_messages = 0
             total_chars = 0
-            
+
             for i in range(current_index - 1, -1, -1):
                 check_props = children[i].get("properties", {})
                 check_sender = check_props.get("sender_name", "")
-                
+
                 if check_sender != prev_sender:
                     break
-                
+
                 consecutive_messages += 1
                 total_chars += len(check_props.get("text_content", ""))
-            
+
             # Consider it a break only if the previous sender had substantial content:
             # - 3+ consecutive messages OR
             # - >500 characters of content
             if consecutive_messages >= 3 or total_chars > 500:
                 logger.debug(f"Sender change break: {prev_sender} → {current_sender} after {consecutive_messages} messages ({total_chars} chars)")
                 return True
-            
+
             return False
-            
+
         except Exception as e:
             logger.debug(f"Error checking sender change: {e}")
             return False
@@ -2152,27 +2152,27 @@ class CompressionEngineComponent(Component):
         try:
             current_props = children[current_index].get("properties", {})
             current_attachments = current_props.get("attachment_metadata", [])
-            
+
             # Current message has attachments - check if previous didn't
             if current_attachments and current_index > 0:
                 prev_props = children[current_index - 1].get("properties", {})
                 prev_attachments = prev_props.get("attachment_metadata", [])
-                
+
                 if not prev_attachments:
                     logger.debug(f"Attachment boundary break: message {current_index} introduces attachments")
                     return True
-            
+
             # Previous message had attachments - check if current doesn't
             if not current_attachments and current_index > 0:
                 prev_props = children[current_index - 1].get("properties", {})
                 prev_attachments = prev_props.get("attachment_metadata", [])
-                
+
                 if prev_attachments:
                     logger.debug(f"Attachment boundary break: message {current_index} ends attachment sequence")
                     return True
-            
+
             return False
-            
+
         except Exception as e:
             logger.debug(f"Error checking attachment boundary: {e}")
-            return False 
+            return False

--- a/elements/elements/components/hud/hud_component.py
+++ b/elements/elements/components/hud/hud_component.py
@@ -67,7 +67,7 @@ class HUDComponent(Component):
     async def get_agent_context(self, options: Optional[Dict[str, Any]] = None) -> Union[str, Dict[str, Any]]:
         """
         Generate agent context using modular rendering functions.
-        
+
         Args:
             options: Optional dictionary controlling which rendering function to use:
                      - render_type: 'memory', 'focused', 'full', or 'combined' (default: 'combined')
@@ -81,13 +81,13 @@ class HUDComponent(Component):
         """
         logger.debug(f"Generating agent context for {self.owner.id}...")
         options = options or {}
-        
+
         render_type = options.get('render_type', 'combined')  # Changed default from 'full' to 'combined'
-        
+
         # Set default render_style to use rich tags for better structure
         if 'render_style' not in options:
             options['render_style'] = 'verbose_tags'
-        
+
         try:
             if render_type == 'memory':
                 context = await self.render_memory_frame_part(options)
@@ -100,7 +100,7 @@ class HUDComponent(Component):
             else:
                 logger.warning(f"Unknown render_type '{render_type}', falling back to full rendering")
                 context = await self.render_full_frame(options)
-            
+
             # FIXED: Auto-detect multimodal content for all render types
             # (render_combined_frame already handles this internally, so check if it's a dict)
             if isinstance(context, dict):
@@ -112,31 +112,31 @@ class HUDComponent(Component):
                 if focus_element_id and self.owner:
                     # OPTIMIZED: Single-pass detection and extraction instead of separate operations
                     return await self._detect_and_extract_multimodal_content(context, options, focus_element_id)
-                
+
                 # No multimodal content detected, return text
                 return context
             else:
                 # Fallback for unexpected types
                 return context
-                
+
         except Exception as e:
             logger.error(f"Error in get_agent_context with render_type '{render_type}': {e}", exc_info=True)
             # Fallback to basic full rendering
             fallback_context = await self.render_full_frame({})
             return fallback_context
-    
+
     async def _extract_multimodal_content(self, text_context: str, options: Dict[str, Any], focus_element_id: str) -> Dict[str, Any]:
         """
         Extract multimodal content from VEIL and return structured data.
-        
+
         OPTIMIZED: Uses targeted element filtering when focus_element_id is provided,
         then recursively searches through those nodes for maximum efficiency.
-        
+
         Args:
             text_context: The rendered text context
             options: Rendering options
             focus_element_id: Element ID to search for attachments
-            
+
         Returns:
             Dictionary with 'text' and 'attachments' keys
         """
@@ -154,75 +154,75 @@ class HUDComponent(Component):
                 # Fall back to full VEIL search if no focus element
                 attachment_nodes = self._find_attachment_nodes_recursively()
                 logger.info(f"[{self.owner.id}] Using full VEIL search (no focus element)")
-            
+
             # Process attachment nodes into LiteLLM-compatible format
             processed_attachments = []
             for attachment_node in attachment_nodes:
                 processed_attachment = await self._process_attachment_node_for_llm(attachment_node)
                 if processed_attachment:
                     processed_attachments.append(processed_attachment)
-            
+
             logger.info(f"[{self.owner.id}] Extracted {len(processed_attachments)} multimodal attachments using optimized search")
 
             return {
                 "text": text_context,
                 "attachments": processed_attachments
             }
-            
+
         except Exception as e:
             logger.error(f"[{self.owner.id}] Error extracting multimodal content: {e}", exc_info=True)
             return {"text": text_context, "attachments": []}
-    
+
     def _find_attachment_nodes_for_element(self, element_id: str) -> List[Dict[str, Any]]:
         """
         NEW: Efficiently find attachment nodes for a specific element using granular filtering.
-        
+
         This is much more efficient than searching the entire VEIL when we know which element
         we're interested in.
-        
+
         Args:
             element_id: The element ID to search for attachments
-            
+
         Returns:
             List of attachment content node dictionaries
         """
         try:
             attachment_nodes = []
-            
+
             # Get only the VEIL nodes for this specific element
             element_nodes = self.owner.get_veil_nodes_by_owner(element_id)
             if not element_nodes:
                 logger.debug(f"No VEIL nodes found for element {element_id}")
                 return []
-            
+
             # Recursively search through this element's nodes
             def search_node_for_attachments(node: Dict[str, Any]):
                 if not isinstance(node, dict):
                     return
-                
+
                 # Check if this node is an attachment content item
                 node_type = node.get("node_type", "")
                 props = node.get("properties", {})
                 structural_role = props.get("structural_role", "")
-                
-                if (node_type == "attachment_content_item" or 
+
+                if (node_type == "attachment_content_item" or
                     structural_role == "attachment_content"):
                     # Found an attachment node!
                     attachment_nodes.append(node)
                     logger.debug(f"Found attachment node {node.get('veil_id')} for element {element_id}")
-                
+
                 # Recursively search children
                 children = node.get("children", [])
                 for child in children:
                     search_node_for_attachments(child)
-            
+
             # Search through all nodes owned by this element
             for veil_id, node_data in element_nodes.items():
                 search_node_for_attachments(node_data)
-            
+
             logger.debug(f"Found {len(attachment_nodes)} attachment nodes for element {element_id}")
             return attachment_nodes
-            
+
         except Exception as e:
             logger.error(f"Error finding attachment nodes for element {element_id}: {e}", exc_info=True)
             return []
@@ -230,54 +230,54 @@ class HUDComponent(Component):
     def _find_attachment_nodes_recursively(self) -> List[Dict[str, Any]]:
         """
         NEW: Recursively search through the entire VEIL hierarchy to find attachment content nodes.
-        
+
         This handles the case where attachment nodes are children of message nodes rather than
         top-level nodes in the flat VEIL cache.
-        
+
         Returns:
             List of attachment content node dictionaries
         """
         try:
             attachment_nodes = []
-            
+
             # Get the full VEIL from SpaceVeilProducer to search through hierarchy
             veil_producer = self._get_space_veil_producer()
             if not veil_producer:
                 logger.warning(f"Cannot find attachments: SpaceVeilProducer not available")
                 return []
-            
+
             full_veil = veil_producer.get_full_veil()
             if not full_veil:
                 logger.debug(f"No VEIL available for attachment search")
                 return []
-            
+
             # Recursively search through VEIL hierarchy
             def search_node_for_attachments(node: Dict[str, Any]):
                 if not isinstance(node, dict):
                     return
-                
+
                 # Check if this node is an attachment content item
                 node_type = node.get("node_type", "")
                 props = node.get("properties", {})
                 structural_role = props.get("structural_role", "")
-                
-                if (node_type == "attachment_content_item" or 
+
+                if (node_type == "attachment_content_item" or
                     structural_role == "attachment_content"):
                     # Found an attachment node!
                     attachment_nodes.append(node)
                     logger.debug(f"Found attachment node {node.get('veil_id')} at depth")
-                
+
                 # Recursively search children
                 children = node.get("children", [])
                 for child in children:
                     search_node_for_attachments(child)
-            
+
             # Start recursive search from root
             search_node_for_attachments(full_veil)
-            
+
             logger.debug(f"Found {len(attachment_nodes)} attachment nodes through recursive search")
             return attachment_nodes
-            
+
         except Exception as e:
             logger.error(f"Error in recursive attachment search: {e}", exc_info=True)
             return []
@@ -285,10 +285,10 @@ class HUDComponent(Component):
     async def _process_attachment_node_for_llm(self, attachment_node: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """
         Process an attachment VEIL node into LiteLLM-compatible format.
-        
+
         Args:
             attachment_node: VEIL node representing attachment content
-            
+
         Returns:
             LiteLLM-compatible content part or None if not processable
         """
@@ -297,15 +297,15 @@ class HUDComponent(Component):
             content_type = props.get("content_nature", "unknown")
             filename = props.get("filename", "unknown_file")
             attachment_id = props.get("attachment_id")
-            
+
             # NEW: Get content directly from VEIL node properties (much simpler!)
             content = props.get("content")
             content_available = props.get("content_available", False)
-            
+
             if "image" in content_type.lower():
                 # For images, we need base64 data
                 logger.debug(f"Processing image attachment: {filename}")
-                
+
                 if content and isinstance(content, str):
                     # Content is available directly in VEIL node
                     return {
@@ -317,11 +317,11 @@ class HUDComponent(Component):
                 else:
                     logger.warning(f"No content available for image attachment {filename} (content_available: {content_available})")
                     return None
-                    
+
             elif "text" in content_type.lower():
                 # For text files, include the content directly
                 logger.debug(f"Processing text attachment: {filename}")
-                
+
                 if content:
                     return {
                         "type": "text",
@@ -334,10 +334,10 @@ class HUDComponent(Component):
                 # For other file types, just mention them
                 logger.debug(f"Unsupported attachment type for LLM: {content_type}")
                 return {
-                    "type": "text", 
+                    "type": "text",
                     "text": f"[Attachment: {filename} (Type: {content_type}) - Content not directly viewable]"
                 }
-                
+
         except Exception as e:
             logger.error(f"Error processing attachment node for LLM: {e}", exc_info=True)
             return None
@@ -345,11 +345,11 @@ class HUDComponent(Component):
     async def render_memory_frame_part(self, options: Dict[str, Any]) -> str:
         """
         Render memory context part of the frame.
-   
-        
+
+
         Args:
             options: Rendering options, should include 'memory_context' with memory data
-            
+
         Returns:
             Rendered memory frame part
         """
@@ -357,30 +357,30 @@ class HUDComponent(Component):
             memory_context = options.get('memory_context')
             if not memory_context:
                 return "[MEMORY]\n(No memory context provided)"
-            
+
             frame_parts = []
-            
+
             # Agent Workspace Header
             workspace_section = self._render_workspace_section(memory_context.get('agent_info', {}))
             if workspace_section:
                 frame_parts.append(workspace_section)
-            
+
             # Scratchpad Section
             scratchpad_section = self._render_scratchpad_section(memory_context.get('scratchpad'))
             if scratchpad_section:
                 frame_parts.append(scratchpad_section)
-            
+
             # Compressed Context Section
             compressed_section = self._render_compressed_context_section(memory_context.get('compressed_context', {}))
             if compressed_section:
                 frame_parts.append(compressed_section)
-            
+
             # No more latest reasoning section - removed in Phase 2 cleanup
-            
+
             memory_frame = "\n\n".join(frame_parts)
             logger.info(f"[{self.owner.id}] Rendered memory frame: {len(memory_frame)} chars, {len(frame_parts)} sections")
             return memory_frame
-            
+
         except Exception as e:
             logger.error(f"[{self.owner.id}] Error rendering memory frame: {e}", exc_info=True)
             return "[MEMORY]\n(Error rendering memory context)"
@@ -388,10 +388,10 @@ class HUDComponent(Component):
     async def render_focused_frame_part(self, options: Dict[str, Any]) -> str:
         """
         Render focused element with essential InnerSpace context.
-        
+
         Args:
             options: Rendering options, should include 'focus_element_id' and optionally 'conversation_context'
-            
+
         Returns:
             Rendered focused frame part
         """
@@ -400,9 +400,9 @@ class HUDComponent(Component):
             if not focus_element_id:
                 logger.warning(f"[{self.owner.id}] No focus_element_id provided for focused rendering")
                 return await self.render_full_frame(options)
-            
+
             conversation_context = options.get('conversation_context', {})
-            
+
             # Find the focused element
             focused_element = None
             if focus_element_id == self.owner.id:
@@ -414,27 +414,27 @@ class HUDComponent(Component):
                     if element.id == focus_element_id or mount_id == focus_element_id:
                         focused_element = element
                         break
-            
+
             if not focused_element:
                 logger.warning(f"[{self.owner.id}] Focused element {focus_element_id} not found, falling back to full context")
                 return await self.render_full_frame(options)
-            
+
             # Build focused rendering: InnerSpace essentials + focused element
             context_parts = []
-            
+
             # InnerSpace Identity & Context
             innerspace_header = self._build_innerspace_identity_context()
             context_parts.append(innerspace_header)
-            
+
             # Essential InnerSpace Components
             essential_components = await self._get_essential_innerspace_components(options)
             if essential_components:
                 context_parts.append(essential_components)
-            
+
             # Focused Element Header
             focus_header = self._build_focused_context_header(focused_element, conversation_context)
             context_parts.append(focus_header)
-            
+
             # Focused Element Content
             focused_veil = self._get_element_veil(focused_element)
             if focused_veil:
@@ -443,11 +443,11 @@ class HUDComponent(Component):
                 context_parts.append(focused_content)
             else:
                 context_parts.append(f"[No content available for {focus_element_id}]")
-            
+
             focused_frame = "\n\n".join(context_parts)
             logger.info(f"[{self.owner.id}] Rendered focused frame: InnerSpace + {focus_element_id} ({len(focused_frame)} chars)")
             return focused_frame
-            
+
         except Exception as e:
             logger.error(f"[{self.owner.id}] Error rendering focused frame: {e}", exc_info=True)
             return await self.render_full_frame(options)
@@ -455,10 +455,10 @@ class HUDComponent(Component):
     async def render_full_frame(self, options: Dict[str, Any]) -> str:
         """
         Render complete space context with all VEIL objects.
-        
+
         Args:
             options: Rendering options (render_style, etc.)
-            
+
         Returns:
             Rendered full frame
         """
@@ -479,10 +479,10 @@ class HUDComponent(Component):
 
             # Render the VEIL structure into a string
             context_string = self._render_veil_node_to_string(full_veil, attention_requests, options, indent=0)
-            
+
             logger.info(f"[{self.owner.id}] Rendered full frame: {len(context_string)} chars")
             return context_string
-            
+
         except Exception as e:
             logger.error(f"[{self.owner.id}] Error rendering full frame: {e}", exc_info=True)
             import json
@@ -491,28 +491,28 @@ class HUDComponent(Component):
     async def render_combined_frame(self, options: Dict[str, Any]) -> Union[str, Dict[str, Any]]:
         """
         Render combined frame with memory + focused element.
-        
+
         Args:
             options: Rendering options, should include 'memory_context' and 'focus_element_id'
-            
+
         Returns:
             Rendered combined frame (string or dict with multimodal content)
         """
         try:
             frame_parts = []
-            
+
             # Memory part
             memory_frame = await self.render_memory_frame_part(options)
             if memory_frame:
                 frame_parts.append(memory_frame)
-            
+
             # Focused part
             focused_frame = await self.render_focused_frame_part(options)
             if focused_frame:
                 frame_parts.append(focused_frame)
-            
+
             combined_text = "\n\n".join(frame_parts)
-            
+
             # OPTIMIZED: Single pass detection + extraction instead of two separate searches
             focus_element_id = options.get('focus_element_id')
             if focus_element_id and self.owner:
@@ -522,7 +522,7 @@ class HUDComponent(Component):
                 # No focus element - return text only
                 logger.info(f"[{self.owner.id}] Rendered combined frame: {len(combined_text)} chars, {len(frame_parts)} parts")
                 return combined_text
-            
+
         except Exception as e:
             logger.error(f"[{self.owner.id}] Error rendering combined frame: {e}", exc_info=True)
             # Fallback to full frame
@@ -531,45 +531,45 @@ class HUDComponent(Component):
     async def _detect_and_extract_multimodal_content(self, text_context: str, options: Dict[str, Any], focus_element_id: str) -> Union[str, Dict[str, Any]]:
         """
         OPTIMIZED: Single-pass multimodal detection and extraction.
-        
+
         Combines detection and extraction into one efficient operation, eliminating
         the need for separate detection + extraction searches.
-        
+
         Args:
             text_context: The rendered text context
             options: Rendering options
             focus_element_id: Element ID to check for live attachments
-            
+
         Returns:
             Text string if no multimodal content, or dict with 'text' and 'attachments' if multimodal
         """
         try:
             # Single search operation - find attachments and process them if found
             attachment_nodes = self._find_attachment_nodes_for_element(focus_element_id)
-            
+
             if not attachment_nodes:
                 # No multimodal content found - return text only
                 logger.debug(f"No live attachment content found for element {focus_element_id}")
                 logger.info(f"[{self.owner.id}] Rendered combined frame: {len(text_context)} chars (text-only)")
                 return text_context
-            
+
             # Multimodal content found - process attachments immediately
             logger.info(f"[{self.owner.id}] Live multimodal content detected, processing {len(attachment_nodes)} attachments")
-            
+
             # Process attachment nodes into LiteLLM-compatible format
             processed_attachments = []
             for attachment_node in attachment_nodes:
                 processed_attachment = await self._process_attachment_node_for_llm(attachment_node)
                 if processed_attachment:
                     processed_attachments.append(processed_attachment)
-            
+
             logger.info(f"[{self.owner.id}] Extracted {len(processed_attachments)} multimodal attachments in single pass")
 
             return {
                 "text": text_context,
                 "attachments": processed_attachments
             }
-            
+
         except Exception as e:
             logger.error(f"[{self.owner.id}] Error in combined multimodal detection/extraction: {e}", exc_info=True)
             # Fallback to text-only on error
@@ -578,111 +578,111 @@ class HUDComponent(Component):
     def _has_live_multimodal_content_for_element(self, element_id: str) -> bool:
         """
         OPTIMIZED: Check if element has LIVE multimodal content using granular filtering + recursive search.
-        
+
         This only looks for fresh attachment content, not compressed memory descriptions.
         Compressed memories containing attachment descriptions are rendered as text.
-        
-        OPTIMIZED: First filters VEIL nodes by element_id, then recursively searches only 
+
+        OPTIMIZED: First filters VEIL nodes by element_id, then recursively searches only
         through those nodes for efficiency.
-        
+
         Args:
             element_id: Element ID to check for live attachments
-            
+
         Returns:
             True if live attachment nodes are found
         """
         try:
             if not self.owner:
                 return False
-            
+
             # OPTIMIZED: First get only the VEIL nodes for this specific element
             element_nodes = self.owner.get_veil_nodes_by_owner(element_id)
             if not element_nodes:
                 logger.debug(f"No VEIL nodes found for element {element_id}")
                 return False
-            
+
             # OPTIMIZED: Recursively search only through this element's nodes
             def search_element_nodes_for_attachments(nodes_dict: Dict[str, Any]) -> bool:
                 for veil_id, node_data in nodes_dict.items():
                     if not isinstance(node_data, dict):
                         continue
-                    
+
                     # Check if this node is an attachment content item
                     node_type = node_data.get("node_type", "")
                     props = node_data.get("properties", {})
                     structural_role = props.get("structural_role", "")
                     content_nature = props.get("content_nature", "")
-                    
+
                     # If this is an attachment node
-                    if (node_type == "attachment_content_item" or 
+                    if (node_type == "attachment_content_item" or
                         structural_role == "attachment_content" or
                         content_nature.startswith("image") or
                         content_nature == "attachment_content"):
-                        
+
                         # Make sure this is NOT a compressed memory describing attachments
                         if node_type not in ["content_memory", "memorized_content"]:
                             logger.debug(f"Found live attachment node {veil_id} for element {element_id}")
                             return True
-                    
+
                     # OPTIMIZED: Also check if this node has children with attachments
                     if self._node_has_attachment_children(node_data):
                         return True
-                
+
                 return False
-            
+
             # Search through the element's nodes
             has_attachments = search_element_nodes_for_attachments(element_nodes)
-            
+
             if not has_attachments:
                 logger.debug(f"No live attachment content found for element {element_id}")
-            
+
             return has_attachments
-            
+
         except Exception as e:
             logger.error(f"Error checking live multimodal content for element {element_id}: {e}", exc_info=True)
             return False
-    
+
     def _node_has_attachment_children(self, node: Dict[str, Any]) -> bool:
         """
         NEW: Recursively check if a node has attachment children.
-        
+
         This efficiently searches through a node's children hierarchy to find attachment nodes.
-        
+
         Args:
             node: VEIL node to search through
-            
+
         Returns:
             True if attachment children are found
         """
         try:
             children = node.get("children", [])
-            
+
             for child in children:
                 if not isinstance(child, dict):
                     continue
-                
+
                 # Check if this child is an attachment
                 child_node_type = child.get("node_type", "")
                 child_props = child.get("properties", {})
                 child_structural_role = child_props.get("structural_role", "")
                 child_content_nature = child_props.get("content_nature", "")
-                
-                if (child_node_type == "attachment_content_item" or 
+
+                if (child_node_type == "attachment_content_item" or
                     child_structural_role == "attachment_content" or
                     child_content_nature.startswith("image") or
                     child_content_nature == "attachment_content"):
-                    
+
                     # Make sure this is NOT a compressed memory
                     if child_node_type not in ["content_memory", "memorized_content"]:
                         logger.debug(f"Found attachment child: {child.get('veil_id')}")
                         return True
-                
+
                 # Recursively check this child's children
                 if self._node_has_attachment_children(child):
                     return True
-            
+
             return False
-            
+
         except Exception as e:
             logger.error(f"Error checking node children for attachments: {e}", exc_info=True)
             return False
@@ -692,39 +692,39 @@ class HUDComponent(Component):
         agent_name = agent_info.get('agent_name', 'Unknown Agent')
         workspace_desc = agent_info.get('workspace_description', 'Agent workspace')
         total_interactions = agent_info.get('total_stored_interactions', 0)
-        
+
         return f"[AGENT WORKSPACE]\n{workspace_desc}\nAgent: {agent_name} | Total interactions in memory: {total_interactions}"
 
     def _render_scratchpad_section(self, scratchpad_data: Optional[Dict[str, Any]]) -> Optional[str]:
         """Render the scratchpad section if data exists."""
         if not scratchpad_data:
             return "[SCRATCHPAD]\n(Empty - no scratchpad data available)"
-        
+
         # TODO: Implement actual scratchpad rendering when scratchpad functionality is added
         return "[SCRATCHPAD]\n(Scratchpad functionality not yet implemented)"
 
     def _render_compressed_context_section(self, compressed_data: Dict[str, Any]) -> Optional[str]:
         """Render compressed context of other conversations/interactions."""
         interaction_count = compressed_data.get('interaction_count', 0)
-        
+
         if interaction_count == 0:
             return "[COMPRESSED CONTEXT]\n(No previous interactions to reference)"
-        
+
         summary = compressed_data.get('summary', f"I have {interaction_count} previous interactions.")
         recent_interactions = compressed_data.get('recent_interactions', [])
-        
+
         context_parts = [f"[COMPRESSED CONTEXT]\n{summary}"]
-        
+
         if recent_interactions:
             context_parts.append("Recent interactions:")
             for interaction in recent_interactions:
                 interaction_summary = interaction.get('summary', 'Unknown context')
                 tool_count = interaction.get('tool_calls_made', 0)
                 interaction_index = interaction.get('interaction_index', '?')
-                
+
                 tools_text = f" (used {tool_count} tools)" if tool_count > 0 else ""
                 context_parts.append(f"  {interaction_index}. {interaction_summary}{tools_text}")
-        
+
         return "\n".join(context_parts)
 
     def _build_innerspace_identity_context(self) -> str:
@@ -732,60 +732,60 @@ class HUDComponent(Component):
         # Get basic InnerSpace info
         space_name = getattr(self.owner, 'name', 'Unknown InnerSpace')
         space_id = self.owner.id
-        
+
         # Try to get agent name from the space
         agent_name = getattr(self.owner, 'agent_name', None)
         if not agent_name and hasattr(self.owner, 'name'):
             agent_name = self.owner.name
-        
+
         # Build identity context
         identity_parts = [
             f"[AGENT WORKSPACE] {space_name}",
         ]
-        
+
         if agent_name:
             identity_parts.append(f"Agent: {agent_name}")
-        
+
         identity_parts.append(f"Space Type: {self.owner.__class__.__name__}")
-        
+
         # Add any InnerSpace-specific properties
         if hasattr(self.owner, 'description') and self.owner.description:
             identity_parts.append(f"Purpose: {self.owner.description}")
-        
+
         return " | ".join(identity_parts)
 
     async def _get_essential_innerspace_components(self, options: Dict[str, Any]) -> Optional[str]:
         """
         Get essential InnerSpace components that should always be visible.
-        
+
         Args:
             options: Rendering options
-            
+
         Returns:
             Rendered essential components or None if none found
         """
         try:
             essential_parts = []
-            
+
             # Look for scratchpad or similar essential components
             if hasattr(self.owner, '_flat_veil_cache'):
                 flat_cache = self.owner._flat_veil_cache
-                
+
                 for veil_id, veil_node in flat_cache.items():
                     node_props = veil_node.get('properties', {})
                     node_type = veil_node.get('node_type', '')
                     content_nature = node_props.get('content_nature', '')
-                    
+
                     # Include scratchpad content
                     if 'scratchpad' in node_type.lower() or 'scratchpad' in content_nature.lower():
                         scratchpad_content = self._render_veil_node_to_string(veil_node, {}, options, indent=0)
                         essential_parts.append(f"[SCRATCHPAD]\n{scratchpad_content}")
-                    
+
                     # Include other essential components as needed
                     # Could add agent status, important state, etc.
-            
+
             return "\n\n".join(essential_parts) if essential_parts else None
-            
+
         except Exception as e:
             logger.warning(f"[{self.owner.id}] Error getting essential components: {e}")
             return None
@@ -794,45 +794,45 @@ class HUDComponent(Component):
         """Build a descriptive header for the focused conversation element."""
         element_name = getattr(focused_element, 'name', 'Unknown Element')
         element_type = focused_element.__class__.__name__
-        
+
         header = f"[ACTIVE CONVERSATION] {element_name} ({element_type})"
-        
+
         # Add conversation details if available
         if conversation_context:
             is_dm = conversation_context.get('is_dm', False)
             recent_sender = conversation_context.get('recent_sender')
             adapter_id = conversation_context.get('adapter_id')
             recent_preview = conversation_context.get('recent_message_preview', '')
-            
+
             context_details = []
             if is_dm:
                 context_details.append("Direct Message")
             else:
                 context_details.append("Channel/Group")
-                
+
             if recent_sender:
                 context_details.append(f"Recent activity from: {recent_sender}")
-                
+
             if adapter_id:
                 context_details.append(f"Platform: {adapter_id}")
-            
+
             if context_details:
                 header += f" - {' | '.join(context_details)}"
-                
+
             # Add preview of recent activity
             if recent_preview:
                 preview = recent_preview[:80] + "..." if len(recent_preview) > 80 else recent_preview
                 header += f"\nRecent: \"{preview}\""
-        
+
         return header
 
     def _get_element_veil(self, element) -> Optional[Dict[str, Any]]:
         """
         Get the VEIL representation for a specific element using granular filtering.
-        
+
         Args:
             element: The element to get VEIL data for
-            
+
         Returns:
             VEIL node data for the element with properly reconstructed hierarchy, or None if not available
         """
@@ -841,42 +841,42 @@ class HUDComponent(Component):
             if not self.owner:
                 logger.warning(f"Cannot get element VEIL: No owner InnerSpace")
                 return None
-            
+
             # Get all VEIL nodes belonging to this element
             element_nodes = self.owner.get_veil_nodes_by_owner(element.id)
-            
+
             if not element_nodes:
                 logger.debug(f"No VEIL nodes found for element {element.id}")
                 return None
-            
+
             # Find the root/container node for this element
             container_nodes = {
-                veil_id: node_data 
+                veil_id: node_data
                 for veil_id, node_data in element_nodes.items()
-                if isinstance(node_data, dict) and 
+                if isinstance(node_data, dict) and
                 node_data.get("properties", {}).get("structural_role") == "container"
             }
-            
+
             if container_nodes:
                 # Return the first container node found (should typically be only one)
                 container_veil_id, container_node = next(iter(container_nodes.items()))
-                
+
                 # NEW: Properly reconstruct hierarchy using parent-child relationships
                 # Instead of just flattening children, reconstruct the proper hierarchy
                 reconstructed_container = copy.deepcopy(container_node)
-                
+
                 # Build hierarchy by finding child nodes and organizing them by parent_id
                 child_nodes_by_parent = {}
                 root_children = []
-                
+
                 for veil_id, node_data in element_nodes.items():
                     if veil_id == container_veil_id:
                         continue  # Skip the container itself
-                    
+
                     if isinstance(node_data, dict):
                         props = node_data.get("properties", {})
                         parent_id = props.get("parent_id")
-                        
+
                         # If parent_id points to the container, it's a direct child
                         if parent_id == container_veil_id:
                             root_children.append(copy.deepcopy(node_data))
@@ -888,7 +888,7 @@ class HUDComponent(Component):
                         else:
                             # No parent_id, treat as direct child
                             root_children.append(copy.deepcopy(node_data))
-                
+
                 # NEW: Recursively attach children to their parents to maintain hierarchy
                 def attach_children_recursively(node):
                     node_veil_id = node.get("veil_id")
@@ -897,50 +897,50 @@ class HUDComponent(Component):
                         # Recursively process the children
                         for child in node["children"]:
                             attach_children_recursively(child)
-                
+
                 # Attach children to root-level nodes
                 for child in root_children:
                     attach_children_recursively(child)
-                
+
                 # Set the properly organized children on the container
                 reconstructed_container["children"] = root_children
-                
+
                 logger.debug(f"Retrieved VEIL for element {element.id}: container + {len(root_children)} root children (hierarchy preserved)")
                 return reconstructed_container
             else:
                 # No container found, create a synthetic one from all nodes but still preserve hierarchy
                 logger.debug(f"No container node found for element {element.id}, creating synthetic structure with hierarchy")
-                
+
                 # Try to build hierarchy from all available nodes
                 nodes_by_veil_id = {veil_id: copy.deepcopy(node_data) for veil_id, node_data in element_nodes.items()}
                 root_nodes = []
-                
+
                 # Find root nodes (no parent or parent not in this element's nodes)
                 for veil_id, node_data in nodes_by_veil_id.items():
                     props = node_data.get("properties", {})
                     parent_id = props.get("parent_id")
-                    
+
                     if not parent_id or parent_id not in nodes_by_veil_id:
                         root_nodes.append(node_data)
-                
+
                 # Build hierarchy recursively
                 def build_synthetic_hierarchy(node):
                     node_veil_id = node.get("veil_id")
                     children = []
-                    
+
                     for other_veil_id, other_node in nodes_by_veil_id.items():
                         if other_veil_id != node_veil_id:
                             other_props = other_node.get("properties", {})
                             if other_props.get("parent_id") == node_veil_id:
                                 child_with_hierarchy = build_synthetic_hierarchy(other_node)
                                 children.append(child_with_hierarchy)
-                    
+
                     node["children"] = children
                     return node
-                
+
                 # Build hierarchy for all root nodes
                 hierarchical_roots = [build_synthetic_hierarchy(root) for root in root_nodes]
-                
+
                 return {
                     "veil_id": f"{element.id}_synthetic_root",
                     "node_type": "synthetic_container",
@@ -952,12 +952,12 @@ class HUDComponent(Component):
                     },
                     "children": hierarchical_roots
                 }
-            
+
         except Exception as e:
             logger.error(f"Error getting VEIL for element {element.id}: {e}", exc_info=True)
             return None
 
-    # --- Rendering Helpers --- 
+    # --- Rendering Helpers ---
 
     def _render_space_root(self, node: Dict[str, Any], attention: Dict[str, Any], options: Dict[str, Any], indent_str: str, node_info: str) -> str:
         """Renders the root node of a space VEIL."""
@@ -969,7 +969,7 @@ class HUDComponent(Component):
         header = f"{indent_str}[Space: {element_name} ({element_type})]"
         if is_inner_space:
             header += " (Agent's Inner Space)"
-        
+
         output = f"{header}{indent_str}" # Dynamic separator length
         # Children are handled by the main loop, so this renderer just provides the header.
         return output
@@ -1002,27 +1002,27 @@ class HUDComponent(Component):
         element_id = props.get("element_id", "unknown_id")
         content_nature = props.get("content_nature", "container")
         element_type = props.get("element_type", "Element")
-        
+
         # NEW: Include tool targeting information
         available_tools = props.get("available_tools", [])
         tool_target_element_id = props.get("tool_target_element_id")
-        
+
         # Build header with element information - always include element type and ID for future needs
         header = f"{indent_str}{element_name}"
-        
+
         # NEW: Always show element ID and type (important for targeting and debugging)
         header += f" (ID: {element_id})"
         if element_type != "Element":  # Only show type if it's not generic
             header += f" [{element_type}]"
-        
+
         # Add tool information if available
         if available_tools:
             # NEW: Check if this is a remote element accessed via uplink proxy
             prefix_element_id = self._determine_tool_prefix_element_id(element_id)
-            
+
             # Create short prefix for display (same logic as agent loop)
             short_prefix = self._create_short_element_prefix(prefix_element_id)
-            
+
             # NEW: Get chat prefix mappings if this is an uplink proxy
             chat_prefix_info = ""
             if prefix_element_id != element_id:  # This is a remote element accessed via uplink
@@ -1033,21 +1033,21 @@ class HUDComponent(Component):
                         chat_mappings = urtp.get_chat_prefix_mappings()
                         if chat_mappings:
                             chat_prefix_info = f" (Chat prefixes: {', '.join(f'{p}={n}' for p, n in chat_mappings.items())})"
-            
+
             prefixed_tools = [f"{short_prefix}__{tool}" for tool in available_tools]
-            
+
             if tool_target_element_id and tool_target_element_id != element_id:
                 header += f" - Tools: {', '.join(prefixed_tools)} → {tool_target_element_id}"
             else:
                 header += f" - Tools: {', '.join(prefixed_tools)}"
-                
+
             # If using uplink proxy prefix, add clarification with chat prefix info
             if prefix_element_id != element_id:
                 header += f" (via uplink{chat_prefix_info})"
-        
+
         header += ":"  # End with colon for readability
         output = f"{header}\n"
-        
+
         # Add additional details in verbose mode
         use_verbose_tags = options.get("render_style") == "verbose_tags"
         if use_verbose_tags:
@@ -1055,16 +1055,16 @@ class HUDComponent(Component):
                 output += f"{indent_str}  (Content Nature: {content_nature})\n"
             if tool_target_element_id and tool_target_element_id != element_id:
                 output += f"{indent_str}  (Tool Target: {tool_target_element_id})\n"
-        
+
         return output
 
     def _get_uplink_element_for_remote(self, remote_element_id: str):
         """Helper to find the uplink element that provides access to a remote element."""
         if not self.owner:
             return None
-            
+
         mounted_elements = self.owner.get_mounted_elements()
-        
+
         for mount_id, element in mounted_elements.items():
             # Check if this is an uplink proxy
             if hasattr(element, 'remote_space_id') and hasattr(element, '_remote_tool_provider_component'):
@@ -1080,25 +1080,25 @@ class HUDComponent(Component):
     def _determine_tool_prefix_element_id(self, element_id: str) -> str:
         """
         Determine which element ID should be used for tool prefixing.
-        
+
         For remote elements accessed via uplink proxies, returns the uplink proxy ID.
         For local elements, returns the element ID itself.
-        
+
         Args:
             element_id: The element ID from the VEIL node
-            
+
         Returns:
             Element ID to use for generating tool prefixes
         """
         # Check if this element might be a remote element by looking for uplink proxies
         # that could be proxying tools from this element
-        
+
         if not self.owner:
             return element_id
-            
+
         # Get mounted elements from the InnerSpace
         mounted_elements = self.owner.get_mounted_elements()
-        
+
         for mount_id, element in mounted_elements.items():
             # Check if this is an uplink proxy
             if hasattr(element, 'remote_space_id') and hasattr(element, '_remote_tool_provider_component'):
@@ -1110,17 +1110,17 @@ class HUDComponent(Component):
                         if tool_def.get('provider_element_id') == element_id:
                             # This element's tools are proxied by this uplink
                             return element.id
-        
+
         # If no uplink proxy found, use the element's own ID
         return element_id
 
     def _create_short_element_prefix(self, element_id: str) -> str:
         """
         Create a short prefix for tool names using shared utility for consistency with AgentLoop.
-        
+
         Args:
             element_id: Full element ID
-            
+
         Returns:
             Short prefix for display consistency that matches ^[a-zA-Z0-9_-]+$
         """
@@ -1131,11 +1131,12 @@ class HUDComponent(Component):
         props = node.get("properties", {})
         sender = props.get("sender_name", "Unknown")
         text = props.get("text_content", "")
-        timestamp_iso_val = props.get("timestamp_iso", "") 
+        timestamp_iso_val = props.get("timestamp_iso", "")
         is_edited = props.get("is_edited", False)
         original_external_id = props.get("external_id")
         message_status = props.get("message_status", "received")  # NEW: Get message status
         reactions = props.get("reactions", {})  # NEW: Get reactions
+        error_details = props.get("error_details", None)
 
         formatted_timestamp = "[timestamp N/A]"
         if isinstance(timestamp_iso_val, (int, float)):
@@ -1151,7 +1152,7 @@ class HUDComponent(Component):
         output = f"{indent_str}<timestamp>{formatted_timestamp}</timestamp> <sender>{sender}</sender>: <message>{text}</message>"
         if is_edited:
             output += " (edited)"
-        
+
         # NEW: Add message status indicators for pending states
         if message_status == "pending_send":
             output += " ⏳"
@@ -1161,9 +1162,12 @@ class HUDComponent(Component):
             output += " 🗑️"
         elif message_status == "failed_to_send":
             output += " ❌"
-        
+
         if original_external_id:
             output += f" [ext_id: {original_external_id}]"
+
+        if error_details:
+            output += f" [error: {error_details}]"
 
         # NEW: Render reactions if present
         if reactions:
@@ -1173,14 +1177,14 @@ class HUDComponent(Component):
                     # Filter out pending markers for display
                     actual_users = [u for u in user_list if not u.startswith("pending_")]
                     pending_users = [u for u in user_list if u.startswith("pending_")]
-                    
+
                     user_count = len(actual_users)
                     if user_count > 0:
                         reaction_display = f"{emoji}:{user_count}"
                         if pending_users:
                             reaction_display += "⏳"  # Indicate pending reactions
                         reaction_parts.append(reaction_display)
-            
+
             if reaction_parts:
                 output += f" [{', '.join(reaction_parts)}]"
 
@@ -1222,9 +1226,9 @@ class HUDComponent(Component):
         filename = props.get("filename", "unknown_file")
         content_type = props.get("content_nature", "unknown_type")
         attachment_id = props.get("attachment_id", "unknown_id")
-        
+
         output = f"{indent_str}  >> Attachment: {filename} (Type: {content_type}, ID: {attachment_id})\n"
-        
+
         # Try to get actual content for preview
         try:
             # This is a synchronous preview - for async operations, we'd need a different approach
@@ -1242,45 +1246,45 @@ class HUDComponent(Component):
         except Exception as e:
             logger.warning(f"Error checking attachment content availability: {e}")
             output += f"{indent_str}     [Content status unknown]\n"
-        
+
         return output
 
     def _render_memory_context(self, node: Dict[str, Any], attention: Dict[str, Any], options: Dict[str, Any], indent_str: str, node_info: str) -> str:
         """Renders memory context nodes injected by CompressionEngine."""
         props = node.get("properties", {})
         memory_type = props.get("memory_type", "unknown")
-        
+
         if memory_type == "workspace_info":
             agent_name = props.get("agent_name", "Unknown")
             workspace_desc = props.get("workspace_description", "")
             total_interactions = props.get("total_interactions", 0)
-            
+
             output = f"{indent_str}[AGENT WORKSPACE]\n"
             output += f"{indent_str}{workspace_desc}\n"
             output += f"{indent_str}Agent: {agent_name} | Total interactions in memory: {total_interactions}\n"
-            
+
         elif memory_type == "compressed_context":
             interaction_count = props.get("interaction_count", 0)
             summary = props.get("summary", "")
             recent_interactions = props.get("recent_interactions", [])
-            
+
             output = f"{indent_str}[COMPRESSED CONTEXT]\n"
             output += f"{indent_str}{summary}\n"
-            
+
             if recent_interactions:
                 output += f"{indent_str}Recent interactions:\n"
                 for interaction in recent_interactions:
                     interaction_summary = interaction.get('summary', 'Unknown context')
                     tool_count = interaction.get('tool_calls_made', 0)
                     interaction_index = interaction.get('interaction_index', '?')
-                    
+
                     tools_text = f" (used {tool_count} tools)" if tool_count > 0 else ""
                     output += f"{indent_str}  {interaction_index}. {interaction_summary}{tools_text}\n"
         else:
             # Generic memory context (no more reasoning chain support)
             output = f"{indent_str}[MEMORY: {memory_type.upper()}]\n"
             output += f"{indent_str}(Memory context of type {memory_type})\n"
-        
+
         return output
 
     def _render_content_memory(self, node: Dict[str, Any], attention: Dict[str, Any], options: Dict[str, Any], indent_str: str, node_info: str) -> str:
@@ -1289,14 +1293,14 @@ class HUDComponent(Component):
         memory_summary = props.get("memory_summary", "Content summary unavailable")
         original_element_id = props.get("original_element_id", "unknown")
         original_child_count = props.get("original_child_count", 0)
-        
+
         output = f"{indent_str}<content_memory>{memory_summary}</content_memory>\n"
-        
+
         # Add optional compression details in verbose mode
         use_verbose_tags = options.get("render_style") == "verbose_tags"
         if use_verbose_tags:
             output += f"{indent_str}  (Compressed {original_child_count} items from {original_element_id})\n"
-        
+
         return output
 
     def _render_memorized_content(self, node: Dict[str, Any], attention: Dict[str, Any], options: Dict[str, Any], indent_str: str, node_info: str) -> str:
@@ -1309,9 +1313,9 @@ class HUDComponent(Component):
         token_count = props.get("token_count", 0)
         compression_timestamp = props.get("compression_timestamp", "")
         compressor_type = props.get("compressor_type", "unknown")
-        
+
         output = f"{indent_str}<memorized_content>{memory_summary}</memorized_content>\n"
-        
+
         # Add optional compression details in verbose mode
         use_verbose_tags = options.get("render_style") == "verbose_tags"
         if use_verbose_tags:
@@ -1325,7 +1329,7 @@ class HUDComponent(Component):
                     output += f"{indent_str}  (Compressed: {formatted_time})\n"
                 except:
                     output += f"{indent_str}  (Compressed: {compression_timestamp})\n"
-        
+
         return output
 
     def _render_fresh_content(self, node: Dict[str, Any], attention: Dict[str, Any], options: Dict[str, Any], indent_str: str, node_info: str) -> str:
@@ -1335,18 +1339,18 @@ class HUDComponent(Component):
         total_tokens = props.get("total_tokens", 0)
         token_limit = props.get("token_limit", 0)
         is_trimmed = props.get("is_trimmed", False)
-        
+
         if is_trimmed:
             trimmed_count = props.get("trimmed_node_count", 0)
             original_count = props.get("original_node_count", 0)
             trimming_note = props.get("trimming_note", "Content trimmed")
-            
+
             output = f"{indent_str}[{element_id}] {trimming_note}\n"
             output += f"{indent_str}  (Showing {trimmed_count} of {original_count} items, {total_tokens}/{token_limit} tokens)\n"
         else:
             output = f"{indent_str}[{element_id}] Fresh content (compression in progress)\n"
             output += f"{indent_str}  ({total_tokens} tokens, within {token_limit} limit)\n"
-        
+
         # Children will be rendered normally by the main dispatcher
         return output
 
@@ -1356,17 +1360,17 @@ class HUDComponent(Component):
         memory_summary = props.get("memory_summary", "⏳ Processing conversation memory...")
         compression_status = props.get("compression_status", "in_progress")
         original_count = props.get("original_node_count", 0)
-        
+
         output = f"{indent_str}<compression_placeholder>{memory_summary}</compression_placeholder>\n"
-        
+
         # Add status information in verbose mode
         use_verbose_tags = options.get("render_style") == "verbose_tags"
         if use_verbose_tags and original_count > 0:
             output += f"{indent_str}  (Compressing {original_count} items in background, status: {compression_status})\n"
-        
+
         return output
 
-    # --- Main Recursive Renderer (Dispatcher) --- 
+    # --- Main Recursive Renderer (Dispatcher) ---
 
     def _render_veil_node_to_string(self, node: Dict[str, Any], attention: Dict[str, Any], options: Dict[str, Any], indent: int = 0) -> str:
         """
@@ -1374,6 +1378,7 @@ class HUDComponent(Component):
         Dispatches rendering based on node properties/annotations.
         Supports different rendering styles via options['render_style'].
         """
+        #print(f"\n\nnode: {node}\n\n")
         indent_str = "  " * indent
         node_type = node.get("node_type", "unknown")
         props = node.get("properties", {})
@@ -1381,7 +1386,7 @@ class HUDComponent(Component):
         node_id = node.get("veil_id")
         external_id = props.get("external_id")
 
-        # --- Determine Rendering Strategy --- 
+        # --- Determine Rendering Strategy ---
         structural_role = props.get("structural_role")
         content_nature = props.get("content_nature")
         rendering_hint = props.get("rendering_hint")
@@ -1397,7 +1402,7 @@ class HUDComponent(Component):
 
         # Decide which renderer to use based on hints/type (Order matters)
         render_func = self._render_default # Default fallback
-        
+
         if content_nature == "space_summary":
             render_func = self._render_space_root
         elif content_nature == "chat_message":
@@ -1422,12 +1427,12 @@ class HUDComponent(Component):
              render_func = self._render_container
         # Add more dispatch rules here...
         # elif structural_role == "list_item": # Generic list item renderer?
-             # render_func = self._render_list_item 
+             # render_func = self._render_list_item
         # elif content_nature == "space_summary": # Maybe same as container?
              # render_func = self._render_container
 
-        # --- Construct Output --- 
-        output = "" 
+        # --- Construct Output ---
+        output = ""
         node_content_str = "" # Content generated by the specific renderer
 
         # Optional: Add opening tag if verbose style is enabled
@@ -1454,30 +1459,30 @@ class HUDComponent(Component):
              output += f"{content_indent_str}  *ATTENTION: {attention[node_id].get('reason', '')}*\n"
 
         # Render children recursively (always use the main dispatcher)
-        # Only render children if the current node isn't a specific content type 
+        # Only render children if the current node isn't a specific content type
         # that shouldn't have its VEIL children rendered (like a chat message itself)
         if children and render_func not in []: # No longer excluding _render_chat_message
             rendered_children_output = ""
             children_to_render = children # TODO: Apply filtering/limiting here
             # TODO: Sort children based on timestamp or other properties?
-            # Example Sort (if timestamp exists): 
+            # Example Sort (if timestamp exists):
             # children_to_render.sort(key=lambda c: c.get('properties', {}).get('timestamp', 0))
-            
+
             for child_node in children_to_render:
                  # Pass options down for consistent rendering style
                  rendered_children_output += self._render_veil_node_to_string(child_node, attention, options, indent + 1)
-            
+
             # Only add if children produced output (avoid empty <Children> sections)
-            if rendered_children_output: 
+            if rendered_children_output:
                  # Add children output respecting style
                  # In verbose mode, children are naturally indented inside the parent tag
                  # In clean mode, they follow the parent's rendered content
-                 output += rendered_children_output 
-                 
+                 output += rendered_children_output
+
         # Optional: Add closing tag if verbose style is enabled
         if use_verbose_tags:
              output += f"{indent_str}</{node_type}>\n"
-                 
+
         return output # Return accumulated string
 
     # NEW: Unified VEIL Processing Pipeline
@@ -1485,15 +1490,15 @@ class HUDComponent(Component):
     async def get_agent_context_via_compression_engine(self, options: Optional[Dict[str, Any]] = None) -> Union[str, Dict[str, Any]]:
         """
         NEW: Generate agent context using CompressionEngine as VEIL processor for unified rendering.
-        
+
         This creates the unified rendering pipeline where:
         1. CompressionEngine processes full VEIL (compression + memory integration)
         2. HUD renders the processed VEIL using standard rendering methods
         3. All rendering logic is centralized in HUD, CompressionEngine handles preprocessing
-        
+
         Args:
             options: Rendering options including focus_context, memory integration, etc.
-            
+
         Returns:
             Rendered context (string or dict with multimodal content)
         """
@@ -1506,33 +1511,33 @@ class HUDComponent(Component):
                 # Get required components
                 compression_engine = self.get_sibling_component("CompressionEngineComponent")
                 veil_producer = self._get_space_veil_producer()
-                
+
                 if not compression_engine:
                     logger.warning(f"CompressionEngine not available, falling back to standard rendering")
                     span.set_attribute("hud.render.fallback", "no_compression_engine")
                     return await self.get_agent_context(options)
-                
+
                 if not veil_producer:
                     logger.error(f"SpaceVeilProducer not available, cannot generate context")
                     span.set_status(trace.Status(trace.StatusCode.ERROR, "SpaceVeilProducer not found"))
                     return "Error: Could not retrieve internal state."
-                
+
                 # Get full VEIL from SpaceVeilProducer
                 full_veil = veil_producer.get_full_veil()
                 if not full_veil:
                     logger.warning(f"Empty VEIL from SpaceVeilProducer")
                     span.set_attribute("hud.render.status", "empty_veil")
                     return "Current context is empty."
-                
+
                 # Get memory data if needed
                 memory_data = None
                 focus_context = options.get('focus_context')
                 include_memory = options.get('include_memory', True)
-                
+
                 if include_memory:
                     memory_data = await compression_engine.get_memory_data()
                     logger.debug(f"Retrieved memory data for VEIL processing")
-                
+
                 # Process VEIL through CompressionEngine
                 processed_veil = await compression_engine.process_veil_with_compression(
                     full_veil=full_veil,
@@ -1544,12 +1549,12 @@ class HUDComponent(Component):
                 # Set render style
                 if 'render_style' not in options:
                     options['render_style'] = 'verbose_tags'
-                
+
                 # Render the processed VEIL using standard HUD rendering
                 attention_requests = {}  # Could integrate attention system here if needed
                 context_string = self._render_veil_node_to_string(processed_veil, attention_requests, options, indent=0)
                 span.set_attribute("hud.render.output_char_length", len(context_string))
-                
+
                 # FIXED: Auto-detect live multimodal content (consistent with get_agent_context)
                 focus_element_id = focus_context.get('focus_element_id') if focus_context else None
                 if focus_element_id:
@@ -1561,7 +1566,7 @@ class HUDComponent(Component):
                     logger.info(f"Generated context via CompressionEngine pipeline: {len(context_string)} chars (text-only)")
                     span.set_attribute("hud.render.multimodal", False)
                     return context_string
-                    
+
             except Exception as e:
                 logger.error(f"Error in unified CompressionEngine pipeline: {e}", exc_info=True)
                 span.record_exception(e)
@@ -1577,7 +1582,7 @@ class HUDComponent(Component):
             llm_response_text: The raw text output from the LLM.
 
         Returns:
-            A list of action dictionaries. Each dictionary should conform to a 
+            A list of action dictionaries. Each dictionary should conform to a
             structure that AgentLoopComponent can dispatch.
             Example action structure:
             {
@@ -1585,7 +1590,7 @@ class HUDComponent(Component):
                 "target_element_id": "element_id_to_act_on", (optional, for element-specific actions)
                 "target_space_id": "space_id_of_target_element", (optional, defaults to InnerSpace)
                 "target_module": "module_name_for_external_action", (optional, for adapter actions)
-                "parameters": { "param1": "value1", ... } 
+                "parameters": { "param1": "value1", ... }
             }
         """
         logger.debug(f"[{self.owner.id}] HUD processing LLM response: {llm_response_text[:100]}...")
@@ -1597,7 +1602,7 @@ class HUDComponent(Component):
         try:
             import json
             parsed_response = json.loads(llm_response_text)
-            
+
             if isinstance(parsed_response, dict) and "actions" in parsed_response:
                 actions_from_llm = parsed_response.get("actions")
                 if isinstance(actions_from_llm, list):
@@ -1609,7 +1614,7 @@ class HUDComponent(Component):
                             action_to_dispatch = {}
                             action_to_dispatch["action_name"] = llm_action.get("action_type") # or get("action_name")
                             action_to_dispatch["parameters"] = llm_action.get("parameters", {})
-                            
+
                             # Add target_element_id, target_space_id, or target_module if present
                             if "target_element_id" in llm_action:
                                 action_to_dispatch["target_element_id"] = llm_action["target_element_id"]
@@ -1643,7 +1648,7 @@ class HUDComponent(Component):
 
         if not extracted_actions:
             logger.info(f"[{self.owner.id}] No actions extracted from LLM response.")
-        
+
         return extracted_actions
 
     # Optional summarization helper


### PR DESCRIPTION
This is a fix for the issue w/ LLM activation in case of request failure on adpters' side. Basically, the fix ensures that error is propagated to LLM, and LLm is able to see it and to make an intelligent decision about how to handle the failure.

While the fix is actually very small, my editor removed all trailing spaces in files that I debugged to investigate the issue. Therefore, it seems that many files are involved. I do apologise for that. Yet, the actual lines to check are:
- elements/elements/components/hud/hud_component.py (1139, 1169-1171)
- elements/elements/components/messaging/message_list.py (913-922)
- elements/elements/components/messaging/message_list_veil_producer.py (104, 262)