### PR TITLE
Adding scaffolding functionality

### DIFF
--- a/llm/litellm_provider.py
+++ b/llm/litellm_provider.py
@@ -18,26 +18,26 @@ except ImportError:
     LITELLM_AVAILABLE = False
 
 from llm.provider_interface import (
-    LLMProvider, 
-    LLMMessage, 
+    LLMProvider,
+    LLMMessage,
     LLMToolDefinition,
     LLMToolCall,
     LLMResponse
 )
 
 from host.observability import get_tracer
+from .scaffolding_observer import ScaffoldingObserver
 
 logger = logging.getLogger(__name__)
 tracer = get_tracer(__name__)
 
-
 class LiteLLMProvider(LLMProvider):
     """LiteLLM implementation of LLMProvider."""
-    
+
     def __init__(self, default_model: str = "gpt-4", **kwargs):
         """
         Initialize the LiteLLM provider.
-        
+
         Args:
             default_model: The default model to use
             **kwargs: Additional configuration for LiteLLM
@@ -46,19 +46,19 @@ class LiteLLMProvider(LLMProvider):
             raise ImportError(
                 "LiteLLM is not installed. Please install it with: pip install litellm"
             )
-        
+
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.default_model = default_model
         self.config = kwargs
-        
+
         # Apply any custom configuration
         for key, value in kwargs.items():
             if hasattr(litellm, key):
                 setattr(litellm, key, value)
-                
+
         self.logger.info(f"LiteLLM provider initialized with default model: {default_model}")
-    
-    def complete(self, 
+
+    def complete(self,
                  messages: List[LLMMessage],
                  model: Optional[str] = None,
                  temperature: Optional[float] = None,
@@ -67,7 +67,7 @@ class LiteLLMProvider(LLMProvider):
                  **kwargs) -> LLMResponse:
         """
         Generate a completion using LiteLLM.
-        
+
         Args:
             messages: The conversation history
             model: The model to use (defaults to provider's default)
@@ -75,7 +75,7 @@ class LiteLLMProvider(LLMProvider):
             max_tokens: Maximum tokens to generate
             tools: Optional list of tools that the model can use
             **kwargs: Additional provider-specific parameters
-            
+
         Returns:
             A response from the LLM
         """
@@ -86,10 +86,10 @@ class LiteLLMProvider(LLMProvider):
             "llm.provider": "litellm"
         }) as span:
             self.logger.info(f"Generating completion with model: {model_to_use}")
-            
+
             # Format messages for LiteLLM
             litellm_messages = self._format_messages(messages)
-            
+
             # Format tools if provided
             litellm_functions = None
             if tools:
@@ -102,25 +102,25 @@ class LiteLLMProvider(LLMProvider):
                         if validation_issues:
                             self.logger.error(f"Tool '{getattr(tool, 'name', 'UNKNOWN')}' validation failed: {'; '.join(validation_issues)}")
                             continue
-                        
+
                         formatted_tool = self.format_tool_for_provider(tool)
                         litellm_functions.append(formatted_tool)
                         self.logger.debug(f"Successfully formatted tool: {tool.name}")
                     except Exception as e:
                         self.logger.error(f"Error formatting tool '{getattr(tool, 'name', 'UNKNOWN')}': {e}")
                         continue
-                
+
                 self.logger.debug(f"Formatted {len(litellm_functions)} tools successfully")
                 if self.logger.isEnabledFor(logging.DEBUG):
                     # Only stringify tools for debug if debug logging is enabled
                     self.logger.debug(f"LiteLLM tool definitions: {json.dumps(litellm_functions, indent=2)}")
-            
+
             # Prepare parameters
             params = {
                 "model": model_to_use,
                 "messages": litellm_messages,
             }
-            
+
             # Add optional parameters if provided
             if temperature is not None:
                 params["temperature"] = temperature
@@ -128,24 +128,36 @@ class LiteLLMProvider(LLMProvider):
                 params["max_tokens"] = max_tokens
             if litellm_functions:
                 params["tools"] = litellm_functions
-            
+
             # Add any additional kwargs, but filter out scaffolding-specific parameters
             # that are not meant for the underlying LLM provider
             scaffolding_params = {'original_context_data'}
             filtered_kwargs = {k: v for k, v in kwargs.items() if k not in scaffolding_params}
-            
+
             # Log filtered parameters for debugging
             if scaffolding_params.intersection(kwargs.keys()):
                 filtered_out = scaffolding_params.intersection(kwargs.keys())
                 self.logger.debug(f"Filtered out scaffolding-specific parameters: {filtered_out}")
-            
+
             params.update(filtered_kwargs)
-            
+
+            observer = ScaffoldingObserver()
+
             try:
                 # Add request data to the span
                 span.add_event(
-                    "LLM Request", 
+                    "LLM Request",
                     attributes={"llm.request.body": json.dumps(params, default=str)}
+                )
+
+                # Call ScaffoldingObserver to record a request to LLM
+                observer.observe_request(
+                    messages,
+                    model_to_use,
+                    temperature,
+                    max_tokens,
+                    tools,
+                    kwargs.get('original_context_data', None)
                 )
 
                 # Call LiteLLM
@@ -163,18 +175,22 @@ class LiteLLMProvider(LLMProvider):
                     "LLM Response",
                     attributes={"llm.response.body": json.dumps(response_log_data, default=str)}
                 )
-                
+
+                # Call ScaffoldingObserver to record a response from LLM
+                observer.observe_response(parsed_response.content)
+
                 # Add response attributes to the span
                 if parsed_response.usage:
                     span.set_attribute("llm.usage.prompt_tokens", parsed_response.usage.get("prompt_tokens", 0))
                     span.set_attribute("llm.usage.completion_tokens", parsed_response.usage.get("completion_tokens", 0))
                     span.set_attribute("llm.usage.total_tokens", parsed_response.usage.get("total_tokens", 0))
-                
+
                 span.set_attribute("llm.finish_reason", parsed_response.finish_reason or "unknown")
                 if parsed_response.tool_calls:
                     span.set_attribute("llm.tool_calls_count", len(parsed_response.tool_calls))
 
                 span.set_status(trace.Status(trace.StatusCode.OK))
+
                 return parsed_response
 
             except Exception as e:
@@ -185,27 +201,27 @@ class LiteLLMProvider(LLMProvider):
                     content=f"Error: {str(e)}",
                     finish_reason="error"
                 )
-    
+
     def format_tool_for_provider(self, tool: LLMToolDefinition) -> Dict[str, Any]:
         """
         Format a tool definition for LiteLLM.
-        
+
         Args:
             tool: Tool definition with JSON schema parameters
-            
+
         Returns:
             LiteLLM-compatible function definition
         """
         # Validate tool input
         if not isinstance(tool, LLMToolDefinition):
             raise TypeError(f"Expected LLMToolDefinition, got {type(tool)}")
-        
+
         if not tool.name or not isinstance(tool.name, str):
             raise ValueError(f"Tool name must be a non-empty string, got: {tool.name}")
-        
+
         if not isinstance(tool.parameters, dict):
             raise ValueError(f"Tool parameters must be a dict (JSON schema), got {type(tool.parameters)}: {tool.parameters}")
-        
+
         # tool.parameters should be a JSON schema like:
         # {
         #   "type": "object",
@@ -215,7 +231,7 @@ class LiteLLMProvider(LLMProvider):
         #   },
         #   "required": ["param1", "param2"]
         # }
-        
+
         # Build LiteLLM function definition
         function_def = {
             "type": "function",
@@ -225,36 +241,36 @@ class LiteLLMProvider(LLMProvider):
                 "parameters": tool.parameters.copy()  # Use the JSON schema directly
             }
         }
-        
+
         # Validate the JSON schema structure
         if "type" not in tool.parameters:
             self.logger.warning(f"Tool '{tool.name}' parameters missing 'type' field, adding 'object'")
             function_def["function"]["parameters"]["type"] = "object"
-        
+
         if "properties" not in tool.parameters:
             self.logger.warning(f"Tool '{tool.name}' parameters missing 'properties' field, adding empty object")
             function_def["function"]["parameters"]["properties"] = {}
-        
+
         # Ensure required is a list if present
         if "required" in tool.parameters and not isinstance(tool.parameters["required"], list):
             self.logger.warning(f"Tool '{tool.name}' has non-list 'required' field: {tool.parameters['required']}")
             function_def["function"]["parameters"]["required"] = []
-        
+
         # Validate the function definition is JSON serializable
         try:
             json.dumps(function_def)
         except (TypeError, ValueError) as e:
             raise ValueError(f"Tool '{tool.name}' produced non-JSON-serializable definition: {e}")
-        
+
         return function_def
-    
+
     def parse_response(self, raw_response: Any) -> LLMResponse:
         """
         Parse LiteLLM response into standardized LLMResponse.
-        
+
         Args:
             raw_response: LiteLLM response
-            
+
         Returns:
             Standardized LLMResponse
         """
@@ -266,10 +282,10 @@ class LiteLLMProvider(LLMProvider):
                     content="Error: Invalid response structure from LLM",
                     finish_reason="error"
                 )
-            
+
             # Extract the response message
             response_message = raw_response.choices[0].message
-            
+
             # Extract content - handle both dict and object formats
             if hasattr(response_message, 'content'):
                 content = response_message.content
@@ -277,21 +293,21 @@ class LiteLLMProvider(LLMProvider):
                 content = response_message.get("content")
             else:
                 content = str(response_message) if response_message else None
-            
+
             # Extract tool calls if present
             tool_calls = []
-            
+
             # Handle single function call format (older OpenAI format)
             function_call = None
             if hasattr(response_message, 'function_call'):
                 function_call = response_message.function_call
             elif isinstance(response_message, dict) and "function_call" in response_message:
                 function_call = response_message["function_call"]
-                
+
             if function_call:
                 tool_name = function_call.get("name") if isinstance(function_call, dict) else getattr(function_call, "name", None)
                 arguments = function_call.get("arguments") if isinstance(function_call, dict) else getattr(function_call, "arguments", None)
-                
+
                 if tool_name and arguments:
                     # Parse arguments (handle potential JSON parsing errors)
                     try:
@@ -304,16 +320,16 @@ class LiteLLMProvider(LLMProvider):
                     except json.JSONDecodeError as e:
                         self.logger.warning(f"Failed to parse function call arguments as JSON: {e}")
                         parameters = {"raw_arguments": str(arguments)}
-                        
+
                     tool_calls.append(LLMToolCall(tool_name=tool_name, parameters=parameters))
-            
+
             # Handle newer format with multiple tool calls
             tool_calls_list = None
             if hasattr(response_message, 'tool_calls'):
                 tool_calls_list = response_message.tool_calls
             elif isinstance(response_message, dict) and "tool_calls" in response_message:
                 tool_calls_list = response_message["tool_calls"]
-                
+
             if tool_calls_list:
                 for tool_call in tool_calls_list:
                     if isinstance(tool_call, dict):
@@ -331,7 +347,7 @@ class LiteLLMProvider(LLMProvider):
                             arguments = getattr(function_call, "arguments", None)
                         else:
                             continue
-                    
+
                     if tool_name and arguments is not None:
                         # Parse arguments
                         try:
@@ -344,16 +360,16 @@ class LiteLLMProvider(LLMProvider):
                         except json.JSONDecodeError as e:
                             self.logger.warning(f"Failed to parse tool call arguments as JSON: {e}")
                             parameters = {"raw_arguments": str(arguments)}
-                            
+
                         tool_calls.append(LLMToolCall(tool_name=tool_name, parameters=parameters))
-            
+
             # Extract finish reason
             finish_reason = None
             if hasattr(raw_response.choices[0], 'finish_reason'):
                 finish_reason = raw_response.choices[0].finish_reason
             elif isinstance(raw_response.choices[0], dict):
                 finish_reason = raw_response.choices[0].get('finish_reason')
-            
+
             # Extract usage info if available
             usage = None
             if hasattr(raw_response, "usage") and raw_response.usage:
@@ -363,87 +379,87 @@ class LiteLLMProvider(LLMProvider):
                     "completion_tokens": getattr(usage_obj, "completion_tokens", 0),
                     "total_tokens": getattr(usage_obj, "total_tokens", 0)
                 }
-            
+
             return LLMResponse(
                 content=content,
                 tool_calls=tool_calls,
                 finish_reason=finish_reason,
                 usage=usage or {}
             )
-            
+
         except Exception as e:
             self.logger.error(f"Error parsing LLM response: {e}", exc_info=True)
             return LLMResponse(
                 content=f"Error parsing response: {str(e)}",
                 finish_reason="error"
             )
-    
+
     def _format_messages(self, messages: List[LLMMessage]) -> List[Dict[str, Any]]:
         """
         Format messages for LiteLLM.
-        
+
         Args:
             messages: List of LLMMessage objects
-            
+
         Returns:
             List of LiteLLM-compatible message dictionaries
         """
         litellm_messages = []
-        
+
         for message in messages:
             msg_dict = {
                 "role": message.role,
                 "content": message.content  # Can now be string or list for multimodal
             }
-            
+
             # Add name if provided (for function messages)
             if message.name:
                 msg_dict["name"] = message.name
-                
+
             litellm_messages.append(msg_dict)
-            
-        return litellm_messages 
+
+        return litellm_messages
 
 def validate_llm_tool_definition(tool: LLMToolDefinition) -> List[str]:
     """
     Validate an LLMToolDefinition and return a list of issues found.
-    
+
     Args:
         tool: The tool definition to validate
-        
+
     Returns:
         List of validation error messages (empty if valid)
     """
     issues = []
-    
+
     if not isinstance(tool, LLMToolDefinition):
         issues.append(f"Expected LLMToolDefinition, got {type(tool)}")
         return issues
-    
+
     # Check name
     if not tool.name or not isinstance(tool.name, str):
         issues.append(f"Tool name must be a non-empty string, got: {repr(tool.name)}")
-    
+
     # Check description
     if tool.description is not None and not isinstance(tool.description, str):
         issues.append(f"Tool description must be a string or None, got: {type(tool.description)}")
-    
+
     # Check parameters
     if not isinstance(tool.parameters, dict):
         issues.append(f"Tool parameters must be a dict (JSON schema), got {type(tool.parameters)}")
         return issues
-    
+
     # Check JSON schema structure
     if "type" not in tool.parameters:
         issues.append("Parameters schema missing 'type' field")
     elif tool.parameters["type"] != "object":
         issues.append(f"Parameters schema 'type' should be 'object', got: {tool.parameters['type']}")
-    
+
     if "properties" not in tool.parameters:
         issues.append("Parameters schema missing 'properties' field")
     elif not isinstance(tool.parameters["properties"], dict):
         issues.append(f"Parameters 'properties' must be a dict, got {type(tool.parameters['properties'])}")
-    
+
     if "required" in tool.parameters:
         if not isinstance(tool.parameters["required"], list):
             issues.append(f"Parameters 'required' must be a list, got {type(tool.parameters['required'])}")
@@ -453,11 +469,11 @@ def validate_llm_tool_definition(tool: LLMToolDefinition) -> List[str]:
             for req_param in tool.parameters["required"]:
                 if req_param not in properties:
                     issues.append(f"Required parameter '{req_param}' not found in properties")
-    
+
     # Test JSON serialization
     try:
         json.dumps(tool.parameters)
     except (TypeError, ValueError) as e:
         issues.append(f"Parameters not JSON serializable: {e}")
-    
-    return issues 
+
+    return issues

--- a/llm/provider_factory.py
+++ b/llm/provider_factory.py
@@ -12,27 +12,27 @@ from llm.provider_interface import LLMProvider
 
 class LLMProviderFactory:
     """Factory for creating LLM provider instances."""
-    
+
     @staticmethod
     def create_provider(provider_type: str, config: Optional[Dict[str, Any]] = None) -> LLMProvider:
         """
         Create an LLM provider instance based on the specified type.
-        
+
         Args:
             provider_type: The type of provider to create ("litellm", etc.)
             config: Optional configuration for the provider
-            
+
         Returns:
             An LLM provider instance
-            
+
         Raises:
             ValueError: If the provider type is not supported
         """
         logger = logging.getLogger(f"{__name__}.LLMProviderFactory")
         config = config or {}
-        
+
         logger.info(f"Creating LLM provider of type: {provider_type}")
-        
+
         if provider_type.lower() == "litellm":
             try:
                 from llm.litellm_provider import LiteLLMProvider
@@ -49,20 +49,20 @@ class LLMProviderFactory:
         else:
             logger.error(f"Unsupported provider type: {provider_type}")
             raise ValueError(f"Unsupported provider type: {provider_type}")
-    
+
     @classmethod
     def create_from_config(cls, config: Dict[str, Any]) -> LLMProvider:
         """
         Create an LLM provider from a configuration dictionary.
-        
+
         Args:
             config: Configuration dictionary with at least a "type" field
-            
+
         Returns:
             An LLM provider instance
         """
         if "type" not in config:
             raise ValueError("Provider configuration must include a 'type' field")
-        
+
         provider_type = config.pop("type")
-        return cls.create_provider(provider_type, config) 
+        return cls.create_provider(provider_type, config)

--- a/llm/scaffolding_formatter.py
+++ b/llm/scaffolding_formatter.py
@@ -1,0 +1,114 @@
+import logging
+import time
+import threading
+from typing import Dict, Any, List, Optional, Union
+
+from opentelemetry import trace
+from llm.provider_interface import (
+    LLMMessage,
+    LLMToolDefinition
+)
+
+from host.observability import get_tracer
+
+logger = logging.getLogger(__name__)
+tracer = get_tracer(__name__)
+
+class ScaffoldingFormatter:
+    """Formatter implementation for Scaffolding LLMProvider."""
+
+    def format_context(self,
+                       messages: List[LLMMessage],
+                       original_context: Optional[List[Any]] = None) -> List[Dict[str, Any]]:
+        """Format a list of LLMMessages for display in the web interface."""
+        formatted_messages = []
+
+        if original_context and isinstance(original_context, list) and len(original_context) == len(messages):
+            # We have turn-based context - preserve metadata
+            for i, (msg, turn_data) in enumerate(zip(messages, original_context)):
+                formatted_msg = self.format_message(msg)
+                # Add turn metadata from original context
+                if isinstance(turn_data, dict) and 'turn_metadata' in turn_data:
+                    formatted_msg['turn_metadata'] = turn_data['turn_metadata']
+                formatted_messages.append(formatted_msg)
+        else:
+            # Fallback to standard message formatting
+            formatted_messages = [self.format_message(msg) for msg in messages]
+
+        return formatted_messages
+
+    def format_message(self, message: LLMMessage) -> Dict[str, Any]:
+        """Format an LLMMessage for display in the web interface."""
+        try:
+            formatted = {
+                "role": message.role,
+                "content": self._format_content(message.content),
+                "name": getattr(message, 'name', None)
+            }
+
+            # Add metadata about multimodal content
+            if message.is_multimodal():
+                formatted["is_multimodal"] = True
+                formatted["attachment_count"] = message.get_attachment_count()
+                formatted["text_length"] = len(message.get_text_content())
+            else:
+                formatted["is_multimodal"] = False
+                formatted["text_length"] = len(str(message.content))
+
+            # Preserve turn metadata if present (for turn-based messaging)
+            if hasattr(message, 'turn_metadata') and message.turn_metadata:
+                formatted["turn_metadata"] = message.turn_metadata
+
+            return formatted
+
+        except Exception as e:
+            logger.error(f"Error formatting message for display: {e}")
+            return {
+                "role": message.role,
+                "content": f"Error formatting message: {str(e)}",
+                "is_multimodal": False,
+                "text_length": 0
+            }
+
+    def format_tool(self, tool: LLMToolDefinition) -> Dict[str, Any]:
+        """Format a tool definition for display in the web interface."""
+        try:
+            return {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters
+            }
+        except Exception as e:
+            logger.error(f"Error formatting tool for display: {e}")
+            return {
+                "name": "unknown",
+                "description": f"Error formatting tool: {str(e)}",
+                "parameters": {}
+            }
+
+    def _format_content(self, content: Union[str, List[Dict[str, Any]]]) -> str:
+        """Format message content for display in the web interface."""
+        if isinstance(content, str):
+            return content
+
+        if isinstance(content, list):
+            # Handle multimodal content
+            formatted_parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        formatted_parts.append(part.get("text", ""))
+                    elif part.get("type") == "image_url":
+                        url = part.get("image_url", {}).get("url", "unknown")
+                        # Truncate very long URLs for display
+                        display_url = url[:100] + "..." if len(url) > 100 else url
+                        formatted_parts.append(f"[IMAGE: {display_url}]")
+                    elif part.get("type") == "image":
+                        formatted_parts.append("[IMAGE: Base64 data]")
+                    else:
+                        formatted_parts.append(f"[{part.get('type', 'UNKNOWN').upper()}: {str(part)[:50]}...]")
+                else:
+                    formatted_parts.append(str(part))
+            return "\n".join(formatted_parts)
+
+        return str(content)

--- a/llm/scaffolding_observer.py
+++ b/llm/scaffolding_observer.py
@@ -1,0 +1,75 @@
+import logging
+import requests
+import time
+import threading
+from typing import Any, List, Optional
+
+from llm.provider_interface import (
+    LLMMessage,
+    LLMToolDefinition
+)
+from llm.scaffolding_formatter import ScaffoldingFormatter
+
+logger = logging.getLogger(__name__)
+
+class ScaffoldingObserver:
+    """Observer implementation for Scaffolding LLMProvider."""
+
+    def __init__(self, web_server_url: str = "http://localhost:6200"):
+        """
+        Initialize the Scaffolding observer.
+
+        Args:
+            web_server_url: URL of the web interface server
+            timeout: Timeout in seconds for waiting for LLM response
+        """
+        self.web_server_url = web_server_url.rstrip('/')
+        self.session_id = int(time.time())
+        self.formatter = ScaffoldingFormatter()
+
+        logger.info(f"ScaffoldingObserver initialized with web server: {self.web_server_url}")
+
+    def observe_request(self,
+                        messages: List[LLMMessage],
+                        model: Optional[str] = None,
+                        temperature: Optional[float] = None,
+                        max_tokens: Optional[int] = None,
+                        tools: Optional[List[LLMToolDefinition]] = None,
+                        original_context: Optional[List[Any]] = None) -> None:
+        logger.info(f"Sending LLM request to web interface: {self.web_server_url}")
+
+        context_data = {
+            "messages": self.formatter.format_context(messages, original_context),
+            "tools": [self.formatter.format_tool(tool) for tool in (tools or [])],
+            "session_id": self.session_id,
+            "model": model or "unspecified",
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "timestamp": time.time(),
+            "call_number": getattr(self, '_call_counter', 0) + 1
+        }
+        self._call_counter = getattr(self, '_call_counter', 0) + 1
+
+        threading.Thread(
+            target=self._post_to_scaffolding_server,
+            args=(f"{self.web_server_url}/submit-context", context_data),
+            daemon=True
+        ).start()
+
+    def observe_response(self, response: str) -> None:
+        logger.info(f"Sending LLM response to web interface: {self.web_server_url}")
+
+        threading.Thread(
+            target=self._post_to_scaffolding_server,
+            args=(
+                f"{self.web_server_url}/submit-response",
+                {"response": response if response else "No response"}
+            ),
+            daemon=True
+        ).start()
+
+    def _post_to_scaffolding_server(self, url, data):
+        try:
+            requests.post(url, json=data)
+        except Exception as e:
+            logger.debug(f"Background POST to Scaffolding Server failed: {e}")

--- a/llm/scaffolding_provider.py
+++ b/llm/scaffolding_provider.py
@@ -12,6 +12,7 @@ import requests
 from typing import Dict, Any, List, Optional, Union
 
 from llm.provider_interface import LLMProvider, LLMMessage, LLMResponse, LLMToolDefinition
+from .scaffolding_formatter import ScaffoldingFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 class ScaffoldingLLMProvider(LLMProvider):
     """
     Scaffolding LLM provider that redirects to web interface for manual testing.
-    
+
     This provider intercepts LLM calls and sends them to a web interface where
     a human can manually provide responses, enabling:
     - Cost-free testing without actual LLM API calls
@@ -27,11 +28,11 @@ class ScaffoldingLLMProvider(LLMProvider):
     - Debugging of agent loop behavior
     - Edge case testing with specific response scenarios
     """
-    
+
     def __init__(self, web_server_url: str = "http://localhost:6200", timeout: int = 300, **kwargs):
         """
         Initialize the scaffolding provider.
-        
+
         Args:
             web_server_url: URL of the web interface server
             timeout: Timeout in seconds for waiting for manual response
@@ -40,10 +41,11 @@ class ScaffoldingLLMProvider(LLMProvider):
         self.web_server_url = web_server_url.rstrip('/')
         self.timeout = timeout
         self.session_id = int(time.time())
-        
+        self.formatter = ScaffoldingFormatter()
+
         logger.info(f"ScaffoldingLLMProvider initialized with web server: {self.web_server_url}")
-    
-    def complete(self, 
+
+    def complete(self,
                  messages: List[LLMMessage],
                  model: Optional[str] = None,
                  temperature: Optional[float] = None,
@@ -52,43 +54,24 @@ class ScaffoldingLLMProvider(LLMProvider):
                  **kwargs) -> LLMResponse:
         """
         Send messages to web interface and get manual response.
-        
+
         Args:
             messages: List of conversation messages
             model: Model name (for display only)
-            temperature: Temperature setting (for display only)  
+            temperature: Temperature setting (for display only)
             max_tokens: Max tokens setting (for display only)
             tools: Available tools (for display only)
             **kwargs: Additional parameters
-            
+
         Returns:
             LLMResponse with manual input as content
         """
         try:
             logger.info(f"Intercepting LLM call with {len(messages)} messages")
-            
-            # Format context data for display with enhanced turn-based support
-            formatted_messages = []
-            
-            # Try to preserve turn-based structure if available
-            # Check if we have turn-based context in kwargs (passed from agent loop)
-            original_context = kwargs.get('original_context_data')
-            
-            if original_context and isinstance(original_context, list) and len(original_context) == len(messages):
-                # We have turn-based context - preserve metadata
-                for i, (msg, turn_data) in enumerate(zip(messages, original_context)):
-                    formatted_msg = self._format_message_for_display(msg)
-                    # Add turn metadata from original context
-                    if isinstance(turn_data, dict) and 'turn_metadata' in turn_data:
-                        formatted_msg['turn_metadata'] = turn_data['turn_metadata']
-                    formatted_messages.append(formatted_msg)
-            else:
-                # Fallback to standard message formatting
-                formatted_messages = [self._format_message_for_display(msg) for msg in messages]
-            
+
             context_data = {
-                "messages": formatted_messages,
-                "tools": [self._format_tool_for_display(tool) for tool in (tools or [])],
+                "messages": self.formatter.format_context(messages, kwargs.get('original_context_data', None)),
+                "tools": [self.formatter.format_tool(tool) for tool in (tools or [])],
                 "session_id": self.session_id,
                 "model": model or "unspecified",
                 "temperature": temperature,
@@ -96,10 +79,10 @@ class ScaffoldingLLMProvider(LLMProvider):
                 "timestamp": time.time(),
                 "call_number": getattr(self, '_call_counter', 0) + 1
             }
-            
+
             # Increment call counter
             self._call_counter = getattr(self, '_call_counter', 0) + 1
-            
+
             # Send context to web interface and wait for response
             logger.info(f"Sending context to web interface: {self.web_server_url}")
             response = requests.post(
@@ -107,25 +90,25 @@ class ScaffoldingLLMProvider(LLMProvider):
                 json=context_data,
                 timeout=self.timeout
             )
-            
+
             if response.status_code != 200:
                 logger.error(f"Web server returned status {response.status_code}: {response.text}")
                 return LLMResponse(
                     content=f"Error: Web server returned status {response.status_code}",
                     finish_reason="error"
                 )
-            
+
             response_data = response.json()
             manual_response = response_data.get("manual_response", "No response provided")
-            
+
             logger.info(f"Received manual response: {len(manual_response)} characters")
-            
+
             return LLMResponse(
                 content=manual_response,
                 finish_reason="stop",
                 usage={"prompt_tokens": 0, "completion_tokens": len(manual_response.split()), "total_tokens": 0}
             )
-            
+
         except requests.exceptions.Timeout:
             logger.error(f"Timeout waiting for response from web interface after {self.timeout}s")
             return LLMResponse(
@@ -144,105 +127,30 @@ class ScaffoldingLLMProvider(LLMProvider):
                 content=f"Error: {str(e)}",
                 finish_reason="error"
             )
-    
-    def _format_message_for_display(self, message: LLMMessage) -> Dict[str, Any]:
-        """Format an LLMMessage for display in the web interface."""
-        try:
-            formatted = {
-                "role": message.role,
-                "content": self._format_content_for_display(message.content),
-                "name": getattr(message, 'name', None)
-            }
-            
-            # Add metadata about multimodal content
-            if message.is_multimodal():
-                formatted["is_multimodal"] = True
-                formatted["attachment_count"] = message.get_attachment_count()
-                formatted["text_length"] = len(message.get_text_content())
-            else:
-                formatted["is_multimodal"] = False
-                formatted["text_length"] = len(str(message.content))
-            
-            # Preserve turn metadata if present (for turn-based messaging)
-            if hasattr(message, 'turn_metadata') and message.turn_metadata:
-                formatted["turn_metadata"] = message.turn_metadata
-            
-            return formatted
-            
-        except Exception as e:
-            logger.error(f"Error formatting message for display: {e}")
-            return {
-                "role": message.role,
-                "content": f"Error formatting message: {str(e)}",
-                "is_multimodal": False,
-                "text_length": 0
-            }
-    
-    def _format_content_for_display(self, content: Union[str, List[Dict[str, Any]]]) -> str:
-        """Format message content for display in the web interface."""
-        if isinstance(content, str):
-            return content
-        elif isinstance(content, list):
-            # Handle multimodal content
-            formatted_parts = []
-            for part in content:
-                if isinstance(part, dict):
-                    if part.get("type") == "text":
-                        formatted_parts.append(part.get("text", ""))
-                    elif part.get("type") == "image_url":
-                        url = part.get("image_url", {}).get("url", "unknown")
-                        # Truncate very long URLs for display
-                        display_url = url[:100] + "..." if len(url) > 100 else url
-                        formatted_parts.append(f"[IMAGE: {display_url}]")
-                    elif part.get("type") == "image":
-                        formatted_parts.append("[IMAGE: Base64 data]")
-                    else:
-                        formatted_parts.append(f"[{part.get('type', 'UNKNOWN').upper()}: {str(part)[:50]}...]")
-                else:
-                    formatted_parts.append(str(part))
-            return "\n".join(formatted_parts)
-        else:
-            return str(content)
-    
-    def _format_tool_for_display(self, tool: LLMToolDefinition) -> Dict[str, Any]:
-        """Format a tool definition for display in the web interface."""
-        try:
-            return {
-                "name": tool.name,
-                "description": tool.description,
-                "parameters": tool.parameters
-            }
-        except Exception as e:
-            logger.error(f"Error formatting tool for display: {e}")
-            return {
-                "name": "unknown",
-                "description": f"Error formatting tool: {str(e)}",
-                "parameters": {}
-            }
-    
+
     def format_tool_for_provider(self, tool: Dict[str, Any]) -> Any:
         """
         Not needed for scaffolding - tools are displayed in web interface.
-        
+
         Args:
             tool: Tool definition
-            
+
         Returns:
             The tool unchanged
         """
         return tool
-    
+
     def parse_response(self, raw_response: Any) -> LLMResponse:
         """
         Not needed for scaffolding - responses come from web interface.
-        
+
         Args:
             raw_response: Raw response
-            
+
         Returns:
             The response unchanged
         """
         if isinstance(raw_response, LLMResponse):
             return raw_response
         else:
-            return LLMResponse(content=str(raw_response), finish_reason="stop") 
+            return LLMResponse(content=str(raw_response), finish_reason="stop")

--- a/templates/scaffolding_interface.html
+++ b/templates/scaffolding_interface.html
@@ -124,16 +124,18 @@
         }
 
         .metadata-item {
-            display: flex;
+            padding: 5px;
             justify-content: space-between;
         }
 
         .metadata-label {
+            display: block;
             font-weight: 600;
             color: #4a5568;
         }
 
         .metadata-value {
+            display: block;
             color: #2d3748;
             font-family: monospace;
         }
@@ -320,7 +322,7 @@
                 grid-template-columns: 1fr;
                 grid-template-rows: auto auto;
             }
-            
+
             .sidebar {
                 position: static;
                 order: 2;
@@ -402,11 +404,11 @@
             <!-- Current Context Display -->
             <div class="card">
                 <h2>
-                    Current Agent Context 
+                    Current Agent Context
                     <span id="status-indicator" class="status-indicator status-no-context">No Context</span>
                     <span id="refresh-indicator" class="refresh-indicator">Auto-refreshing...</span>
                 </h2>
-                
+
                 <div id="context-metadata" class="context-metadata" style="display: none;">
                     <div class="metadata-item">
                         <span class="metadata-label">Model:</span>
@@ -449,18 +451,19 @@
 
             <!-- Response Input -->
             <div class="card">
-                <h2>Your Response (as LLM)</h2>
-                
+                {% if observer %}
+                    <h2>LLM Response</h2>
+                {% else %}
+                    <h2>Your Response (as LLM)</h2>
+                {% endif %}
+
                 <div id="alert-container"></div>
-                
+
                 <div class="response-section">
-                    <textarea 
-                        id="response-input" 
-                        class="response-input" 
+                    <textarea id="response-input" class="response-input"
                         placeholder="Enter your response as if you were the LLM...&#10;&#10;You can include tool calls in ultra-concise XML format:&#10;&lt;tool_calls&gt;&#10;&lt;tool_name param1=&quot;value1&quot; target_element=&quot;element_name&quot;&gt;&#10;&lt;/tool_calls&gt;&#10;&#10;Or just provide a conversational response."
-                        disabled
-                    ></textarea>
-                    
+                        disabled></textarea>
+
                     <div class="button-group">
                         <button id="submit-btn" class="btn btn-primary" onclick="submitResponse()" disabled>
                             🚀 Submit Response to Agent
@@ -482,7 +485,7 @@
         <!-- Sidebar -->
         <div class="sidebar">
             <h2>Session History</h2>
-            
+
             <div class="button-group" style="margin-bottom: 15px;">
                 <button id="refresh-btn" class="btn btn-secondary" onclick="refreshHistory()">
                     🔄 Refresh
@@ -491,7 +494,7 @@
                     🗑️ Clear History
                 </button>
             </div>
-            
+
             <div id="history-list" class="history-list">
                 <div class="no-context-message">No history yet</div>
             </div>
@@ -500,25 +503,27 @@
 
     <script>
         let currentContext = null;
-        let refreshInterval = null;
+        let contextRefreshInterval = null;
+        let historyRefreshInterval = null;
+        let observer = {{ 'true' if observer else 'false' }};
 
         function formatTurnBasedMessages(messages) {
             let html = '';
-            
+
             messages.forEach((msg, index) => {
                 const roleClass = `message-role-${msg.role}`;
                 const turnMeta = msg.turn_metadata || {};
-                
+
                 // Create turn boundary container
                 html += `<div class="turn-boundary ${roleClass}">`;
-                
+
                 // Turn header with role and metadata
                 let headerText = `${msg.role.toUpperCase()} MESSAGE`;
                 if (turnMeta.turn_index !== undefined) {
                     headerText += ` (Turn ${turnMeta.turn_index})`;
                 }
                 html += `<div class="turn-header">${headerText}</div>`;
-                
+
                 // Turn metadata if available
                 if (Object.keys(turnMeta).length > 0) {
                     let metaText = '';
@@ -532,12 +537,12 @@
                         metaText += `Time: ${start}-${end}`;
                     }
                     metaText = metaText.replace(/ • $/, ''); // Remove trailing separator
-                    
+
                     if (metaText) {
                         html += `<div class="turn-metadata">${metaText}</div>`;
                     }
                 }
-                
+
                 // Message content length info
                 let lengthInfo = '';
                 if (msg.is_multimodal) {
@@ -546,19 +551,19 @@
                     lengthInfo = `[${msg.text_length} chars]`;
                 }
                 html += `<div class="turn-metadata">${lengthInfo}</div>`;
-                
+
                 // Message content (escaped for HTML)
                 const content = msg.content.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
                 html += `<pre style="margin: 0; white-space: pre-wrap; font-family: inherit;">${content}</pre>`;
-                
+
                 html += '</div>'; // Close turn boundary
-                
+
                 // Add spacing between turns
                 if (index < messages.length - 1) {
                     html += '<div style="height: 10px;"></div>';
                 }
             });
-            
+
             return html;
         }
 
@@ -570,13 +575,22 @@
 
         function startAutoRefresh() {
             // Refresh every 2 seconds
-            refreshInterval = setInterval(checkForNewContext, 2000);
+            contextRefreshInterval = setInterval(checkForNewContext, observer ? 1000 : 2000);
+
+            if (observer) {
+                historyRefreshInterval = setInterval(refreshHistory, 500);
+            }
         }
 
         function stopAutoRefresh() {
-            if (refreshInterval) {
-                clearInterval(refreshInterval);
-                refreshInterval = null;
+            if (contextRefreshInterval) {
+                clearInterval(contextRefreshInterval);
+                contextRefreshInterval = null;
+            }
+
+            if (historyRefreshInterval) {
+                clearInterval(historyRefreshInterval);
+                historyRefreshInterval = null;
             }
         }
 
@@ -584,11 +598,14 @@
             try {
                 const response = await fetch('/get-current-context');
                 const data = await response.json();
-                
+
                 if (data.status === 'success') {
                     if (data.has_context && data.context) {
                         displayContext(data.context);
-                        enableResponseInput();
+
+                        if (!observer) {
+                            enableResponseInput();
+                        }
                     } else {
                         showNoContext();
                         disableResponseInput();
@@ -602,34 +619,40 @@
 
         function displayContext(context) {
             currentContext = context;
-            
+
             // Update status indicator
             const statusIndicator = document.getElementById('status-indicator');
-            statusIndicator.textContent = 'Waiting for Response';
-            statusIndicator.className = 'status-indicator status-waiting';
-            
+            if (observer) {
+                statusIndicator.textContent = 'In Observer Mode';
+                statusIndicator.className = 'status-indicator status-no-context';
+            }
+            else {
+                statusIndicator.textContent = 'Waiting for Response';
+                statusIndicator.className = 'status-indicator status-waiting';
+            }
+
             // Show and populate metadata
             const metadataDiv = document.getElementById('context-metadata');
             metadataDiv.style.display = 'grid';
-            
+
             document.getElementById('metadata-model').textContent = context.model || 'unspecified';
             document.getElementById('metadata-messages').textContent = context.messages ? context.messages.length : 0;
             document.getElementById('metadata-tools').textContent = context.tools ? context.tools.length : 0;
             document.getElementById('metadata-session').textContent = context.session_id || '-';
             document.getElementById('metadata-call-number').textContent = context.call_number || '-';
-            
+
             if (context.timestamp) {
                 const date = new Date(context.timestamp * 1000);
                 document.getElementById('metadata-timestamp').textContent = date.toLocaleString();
             }
-            
+
             // Display messages with enhanced turn-based formatting
             const contextDisplay = document.getElementById('context-display');
-            
+
             if (context.messages && context.messages.length > 0) {
                 // Check if messages have turn metadata (turn-based format)
                 const hasTurnMetadata = context.messages.some(msg => msg.turn_metadata);
-                
+
                 if (hasTurnMetadata) {
                     // Enhanced turn-based display
                     contextDisplay.innerHTML = formatTurnBasedMessages(context.messages);
@@ -649,11 +672,11 @@
             } else {
                 contextDisplay.innerHTML = '<div class="no-context-message">No messages in context</div>';
             }
-            
+
             // Display tools
             const toolsSection = document.getElementById('tools-section');
             const toolsList = document.getElementById('tools-list');
-            
+
             if (context.tools && context.tools.length > 0) {
                 toolsSection.style.display = 'block';
                 toolsList.innerHTML = context.tools.map(tool => `
@@ -671,10 +694,10 @@
             const statusIndicator = document.getElementById('status-indicator');
             statusIndicator.textContent = 'No Context';
             statusIndicator.className = 'status-indicator status-no-context';
-            
+
             const metadataDiv = document.getElementById('context-metadata');
             metadataDiv.style.display = 'none';
-            
+
             const contextDisplay = document.getElementById('context-display');
             contextDisplay.innerHTML = `
                 <div class="no-context-message">
@@ -682,7 +705,7 @@
                     <small>Start the Connectome system with CONNECTOME_LLM_TYPE=scaffolding</small>
                 </div>
             `;
-            
+
             const toolsSection = document.getElementById('tools-section');
             toolsSection.style.display = 'none';
         }
@@ -690,10 +713,10 @@
         function enableResponseInput() {
             const responseInput = document.getElementById('response-input');
             const submitBtn = document.getElementById('submit-btn');
-            
+
             responseInput.disabled = false;
             submitBtn.disabled = false;
-            
+
             // Focus on input for immediate use
             responseInput.focus();
         }
@@ -701,7 +724,7 @@
         function disableResponseInput() {
             const responseInput = document.getElementById('response-input');
             const submitBtn = document.getElementById('submit-btn');
-            
+
             responseInput.disabled = true;
             submitBtn.disabled = true;
         }
@@ -709,23 +732,23 @@
         async function submitResponse() {
             const responseInput = document.getElementById('response-input');
             const response = responseInput.value.trim();
-            
+
             if (!response) {
                 showAlert('Please enter a response', 'error');
                 return;
             }
-            
+
             if (!currentContext) {
                 showAlert('No active context to respond to', 'error');
                 return;
             }
-            
+
             try {
                 // Disable input while submitting
                 const submitBtn = document.getElementById('submit-btn');
                 submitBtn.disabled = true;
                 submitBtn.innerHTML = '<span class="loading-spinner"></span> Submitting...';
-                
+
                 const result = await fetch('/submit-response', {
                     method: 'POST',
                     headers: {
@@ -733,18 +756,18 @@
                     },
                     body: JSON.stringify({ response: response })
                 });
-                
+
                 const data = await result.json();
-                
+
                 if (data.status === 'success') {
                     showAlert('Response submitted successfully!', 'success');
                     responseInput.value = '';
-                    
+
                     // Update status
                     const statusIndicator = document.getElementById('status-indicator');
                     statusIndicator.textContent = 'Response Sent';
                     statusIndicator.className = 'status-indicator status-ready';
-                    
+
                     // Refresh history
                     setTimeout(refreshHistory, 500);
                 } else {
@@ -818,7 +841,7 @@ KEY POINTS:
             try {
                 const response = await fetch('/get-history');
                 const data = await response.json();
-                
+
                 if (data.status === 'success') {
                     displayHistory(data.history);
                 }
@@ -829,30 +852,30 @@ KEY POINTS:
 
         function displayHistory(history) {
             const historyList = document.getElementById('history-list');
-            
+
             if (!history || history.length === 0) {
                 historyList.innerHTML = '<div class="no-context-message">No history yet</div>';
                 return;
             }
-            
+
             historyList.innerHTML = history.reverse().map(item => {
                 const timestamp = new Date(item.received_at).toLocaleString();
                 const messageCount = item.messages ? item.messages.length : 0;
                 const toolCount = item.tools ? item.tools.length : 0;
-                
+
                 let statusClass = 'status-no-context';
                 let statusText = item.status;
-                
+
                 if (item.status === 'completed') {
                     statusClass = 'status-ready';
                 } else if (item.status === 'waiting_for_response') {
                     statusClass = 'status-waiting';
                 }
-                
-                const firstMessage = item.messages && item.messages.length > 0 
+
+                const firstMessage = item.messages && item.messages.length > 0
                     ? item.messages[0].content.substring(0, 100) + '...'
                     : 'No messages';
-                
+
                 return `
                     <div class="history-item" onclick="loadHistoryItem(${JSON.stringify(item).replace(/"/g, '&quot;')})">
                         <div class="history-header">
@@ -872,12 +895,12 @@ KEY POINTS:
             displayContext(item);
             // Don't enable input for historical items
             disableResponseInput();
-            
+
             // Update status to show it's historical
             const statusIndicator = document.getElementById('status-indicator');
             statusIndicator.textContent = 'Historical Item';
             statusIndicator.className = 'status-indicator status-no-context';
-            
+
             if (item.response) {
                 document.getElementById('response-input').value = item.response;
             }
@@ -887,11 +910,11 @@ KEY POINTS:
             if (!confirm('Are you sure you want to clear the session history?')) {
                 return;
             }
-            
+
             try {
                 const response = await fetch('/clear-history', { method: 'POST' });
                 const data = await response.json();
-                
+
                 if (data.status === 'success') {
                     showAlert('History cleared', 'success');
                     refreshHistory();
@@ -907,13 +930,13 @@ KEY POINTS:
         function showAlert(message, type) {
             const alertContainer = document.getElementById('alert-container');
             const alertClass = type === 'error' ? 'alert-error' : 'alert-success';
-            
+
             alertContainer.innerHTML = `
                 <div class="alert ${alertClass}">
                     ${message}
                 </div>
             `;
-            
+
             // Auto-remove after 5 seconds
             setTimeout(() => {
                 alertContainer.innerHTML = '';
@@ -936,4 +959,4 @@ KEY POINTS:
         });
     </script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
Added ability to observe LLM interactions via scaffolding server.

The application of changes to actual Connectome functionality (i.e. LiteLLM provider) is automatic; yet, to actually observe LLM/user communication on a platform it is necessary for the scaffolding web server to run in the observer mode. To achieve this just run 'OBSERVER=true python scaffolding_server.py' command instead of simple 'python scaffolding_server.py'.