### PR TITLE
Restore attachments

### DIFF
--- a/elements/elements/components/agent_loop/simple_request_response_loop.py
+++ b/elements/elements/components/agent_loop/simple_request_response_loop.py
@@ -96,7 +96,19 @@ class SimpleRequestResponseLoopComponent(BaseAgentLoopComponent):
 
             # Get aggregated tools and send to LLM
             aggregated_tools = await self.aggregate_tools()
-            # 3. Send rendered context + tools to LLM
+
+            # 3. Cache context for inspector before sending to LLM
+            try:
+                cache_key = hud.cache_llm_context(messages, {
+                    'agent_loop_type': 'SimpleRequestResponseLoop',
+                    'message_count': len(messages),
+                    'tool_count': len(aggregated_tools)
+                })
+                logger.debug(f"Cached LLM context for inspector with key: {cache_key}")
+            except Exception as cache_error:
+                logger.warning(f"Failed to cache LLM context: {cache_error}")
+
+            # 4. Send rendered context + tools to LLM
             # Metadata now travels with LLMMessage objects, no need for original_context_data
             llm_response_obj = llm_provider.complete(messages=messages, tools=aggregated_tools)
 

--- a/elements/elements/components/agent_loop/tool_text_parsing_loop.py
+++ b/elements/elements/components/agent_loop/tool_text_parsing_loop.py
@@ -160,7 +160,18 @@ class ToolTextParsingLoopComponent(BaseAgentLoopComponent):
                 else:
                     logger.debug(f"Message {i} ({msg.role}): {len(msg.get_text_content())} chars")
 
-            # 3. Send rendered context to LLM (no separate tool definitions - they're in the context)
+            # 3. Cache context for inspector before sending to LLM
+            try:
+                cache_key = hud.cache_llm_context(messages, {
+                    'agent_loop_type': 'ToolTextParsingLoop',
+                    'message_count': len(messages),
+                    'has_tools': len(enhanced_tools_from_veil) > 0
+                })
+                logger.debug(f"Cached LLM context for inspector with key: {cache_key}")
+            except Exception as cache_error:
+                logger.warning(f"Failed to cache LLM context: {cache_error}")
+
+            # 4. Send rendered context to LLM (no separate tool definitions - they're in the context)
             # NOTE: We don't pass tools parameter to LLM since they're already rendered in the context
             # Metadata now travels with LLMMessage objects, no need for original_context_data
             if self._is_cancelled():

--- a/elements/elements/components/hud/facet_aware_hud_component.py
+++ b/elements/elements/components/hud/facet_aware_hud_component.py
@@ -320,8 +320,8 @@ class FacetAwareHUDComponent(Component):
             if self._has_multimodal_content(facet_cache):  # Use facet_cache instead of processed_facets
                 # Get the multimodal content formatted for LLM ingestion
                 multimodal_result = await self._detect_and_extract_multimodal_content(
-                    text_content="",  # Empty since we're just extracting attachments
-                    options={'facet_cache': facet_cache}
+                    "",  # Empty since we're just extracting attachments
+                    {'facet_cache': facet_cache}
                 )
                 
                 if isinstance(multimodal_result, dict) and multimodal_result.get('attachments'):

--- a/elements/elements/components/hud/facet_aware_hud_component.py
+++ b/elements/elements/components/hud/facet_aware_hud_component.py
@@ -2245,8 +2245,6 @@ class FacetAwareHUDComponent(Component):
                         if hasattr(component, 'COMPONENT_TYPE') and component.COMPONENT_TYPE == 'MessageListComponent':
                             message_list_components.append(component)
 
-            # Removed system message scanning for fetch_attachment_result - attachments flow through facets
-
             # Also extract from EventFacets (regular messages with attachment metadata)
             for facet in facet_cache.get_facets_by_type(VEILFacetType.EVENT):
                 attachment_metadata = facet.properties.get('attachment_metadata', [])
@@ -2449,7 +2447,6 @@ class FacetAwareHUDComponent(Component):
                     logger.debug(f"[HUD] Found {len(attachment_metadata)} attachments in facet {facet.facet_id}")
                     return True
 
-            # Removed system message scanning for fetch_attachment_result - attachments flow through facets
 
             # Also check StatusFacets for any attachment information
             for facet in facet_cache.get_facets_by_type(VEILFacetType.STATUS):

--- a/elements/elements/components/hud/facet_aware_hud_component.py
+++ b/elements/elements/components/hud/facet_aware_hud_component.py
@@ -53,11 +53,11 @@ class SnapshotCache:
             "evictions": 0,
             "refreshes": 0
         }
-        
+
     def get(self, key: str, max_age_ms: Optional[int] = None) -> Optional[Dict[str, Any]]:
         now = int(time.time() * 1000)
         max_age = max_age_ms or self._ttl_ms
-        
+
         if key in self._cache:
             entry = self._cache[key]
             age = now - entry.timestamp_ms
@@ -69,17 +69,17 @@ class SnapshotCache:
             else:
                 del self._cache[key]
                 self._metrics["evictions"] += 1
-                
+
         self._metrics["misses"] += 1
         return None
-        
+
     def put(self, key: str, data: Dict[str, Any]) -> None:
         self._cache[key] = SnapshotEntry(
             data=data,
             timestamp_ms=int(time.time() * 1000)
         )
         self._metrics["refreshes"] += 1
-        
+
     def get_metrics(self) -> Dict[str, Any]:
         """Return cache metrics with hit rate calculation."""
         total = self._metrics["hits"] + self._metrics["misses"]
@@ -205,7 +205,7 @@ class FacetAwareHUDComponent(Component):
             # Format examples: "discord_conversation_...", "terminal_...", etc.
             if not element_id:
                 return "unknown"
-                
+
             # Try to extract from common patterns
             if "conversation" in element_id.lower():
                 return "conversation"
@@ -228,7 +228,7 @@ class FacetAwareHUDComponent(Component):
         try:
             if not element_id:
                 return "Unknown Element"
-                
+
             # For conversation elements, try to extract conversation name
             if "conversation" in element_id.lower():
                 # Element IDs might contain conversation names after certain patterns
@@ -254,11 +254,11 @@ class FacetAwareHUDComponent(Component):
         if not focus_element_id:
             logger.debug("Cannot record focus change: no focus_element_id provided")
             return
-            
+
         # Extract element type and name from element_id if not provided
         focus_element_type = focus_info.get('focus_element_type', self._extract_element_type_from_id(focus_element_id))
         focus_element_name = focus_info.get('focus_element_name', self._extract_element_name_from_id(focus_element_id))
-        
+
         self._focus_change_history.append({
             "veil_timestamp": ConnectomeEpoch.get_veil_timestamp(),
             "owner_element_id": focus_element_id,
@@ -301,7 +301,7 @@ class FacetAwareHUDComponent(Component):
                 return "Error: VEILFacetCache not available"
 
             facet_cache = veil_producer.get_facet_cache()  # NEW: Get VEILFacetCache
-            
+
             self._extract_current_focus_info(options) # NEW: Extract current focus at HUD level
 
             # Get VEILFacetCompressionEngine
@@ -325,12 +325,12 @@ class FacetAwareHUDComponent(Component):
                     "",  # Empty since we're just extracting attachments
                     {'facet_cache': facet_cache}
                 )
-                
+
                 if isinstance(multimodal_result, dict) and multimodal_result.get('attachments'):
                     # Find user messages that contain attachment metadata and convert them to multimodal
                     attachment_pattern = r'\[Attachment: [^\]]+\]'
                     import re
-                    
+
                     for message in turn_based_messages:
                         if isinstance(message, dict) and message.get('role') == 'user':
                             content = message.get('content', '')
@@ -338,7 +338,7 @@ class FacetAwareHUDComponent(Component):
                                 # This message contains attachment metadata - convert to multimodal format
                                 # Create multimodal content list format
                                 multimodal_content = []
-                                
+
                                 # Add text content (without attachment metadata lines)
                                 text_content = re.sub(attachment_pattern, '', content).strip()
                                 if text_content:
@@ -346,10 +346,10 @@ class FacetAwareHUDComponent(Component):
                                         "type": "text",
                                         "text": text_content
                                     })
-                                
+
                                 # Add all extracted attachments
                                 multimodal_content.extend(multimodal_result['attachments'])
-                                
+
                                 # Update message content
                                 message['content'] = multimodal_content
                                 logger.debug(f"[HUD] Converted message to multimodal format with {len(multimodal_content)} content items")
@@ -2221,43 +2221,43 @@ class FacetAwareHUDComponent(Component):
             facet_cache = options.get('facet_cache')
             if not facet_cache:
                 return text_context
-                
+
             if not self._has_multimodal_content(facet_cache):
                 return text_context
-                
+
             # Extract attachment data from facets and message data
             attachments = []
-            
+
             # First, get the MessageListComponent to access message data directly
             message_list_components = []
-            
+
             # Access mounted elements through the ContainerComponent
             container_component = None
             for component in self.owner.get_components().values():
                 if hasattr(component, 'COMPONENT_TYPE') and component.COMPONENT_TYPE == 'ContainerComponent':
                     container_component = component
                     break
-            
+
             if container_component:
                 mounted_elements = container_component.get_mounted_elements()
                 for element in mounted_elements.values():
                     for component in element.get_components().values():
                         if hasattr(component, 'COMPONENT_TYPE') and component.COMPONENT_TYPE == 'MessageListComponent':
                             message_list_components.append(component)
-            
+
             # Removed system message scanning for fetch_attachment_result - attachments flow through facets
-            
+
             # Also extract from EventFacets (regular messages with attachment metadata)
             for facet in facet_cache.get_facets_by_type(VEILFacetType.EVENT):
                 attachment_metadata = facet.properties.get('attachment_metadata', [])
-                
+
                 for att_meta in attachment_metadata:
                     if isinstance(att_meta, dict):
                         attachment_id = att_meta.get('attachment_id')
                         content_type = att_meta.get('content_type', 'unknown')
                         filename = att_meta.get('filename', 'unknown')
                         content = att_meta.get('content')
-                        
+
                         if content and content_type.startswith('image/'):
                             # Create proper multimodal attachment for LLM processing
                             attachment_info = {
@@ -2286,7 +2286,7 @@ class FacetAwareHUDComponent(Component):
                             }
                             logger.debug(f"[HUD] Added metadata-only attachment {attachment_id} ({filename}) to context")
                             attachments.append(attachment_info)
-                            
+
             if attachments:
                 logger.info(f"[HUD] Extracted {len(attachments)} attachments for multimodal content")
                 return {
@@ -2308,21 +2308,21 @@ class FacetAwareHUDComponent(Component):
             Dictionary with rendering statistics
         """
         return self._rendering_stats.copy()
-        
+
     def cache_llm_context(self, messages: List[Any], context_metadata: Optional[Dict[str, Any]] = None) -> str:
         """
         Cache the actual context being sent to LLM for inspector debugging.
-        
+
         Args:
             messages: The LLMMessage objects being sent to the LLM
             context_metadata: Optional metadata about the context generation
-            
+
         Returns:
             Cache key for retrieval
         """
         import time
         cache_key = f"llm_context_{self.owner.id}_{int(time.time())}"
-        
+
         # Convert messages to serializable format for caching
         serialized_messages = []
         for msg in messages:
@@ -2349,45 +2349,45 @@ class FacetAwareHUDComponent(Component):
             except Exception as e:
                 logger.warning(f"Error serializing message for cache: {e}")
                 serialized_messages.append({'role': 'error', 'content': f'Serialization error: {str(e)}'})
-        
+
         cache_data = {
             'messages': serialized_messages,
             'timestamp': time.time(),
             'space_id': self.owner.id if self.owner else 'unknown',
             'context_metadata': context_metadata or {}
         }
-        
+
         self._llm_context_cache.put(cache_key, cache_data)
         logger.debug(f"Cached LLM context with key: {cache_key}, {len(serialized_messages)} messages")
         return cache_key
-        
+
     def get_cached_llm_context(self, cache_key: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """
         Retrieve cached LLM context for inspector debugging.
-        
+
         Args:
             cache_key: Specific cache key, or None to get most recent
-            
+
         Returns:
             Cached context data or None if not found
         """
         if cache_key:
             return self._llm_context_cache.get(cache_key)
-        
+
         # If no specific key, find most recent entry for this space
         space_id = self.owner.id if self.owner else 'unknown'
         most_recent_key = None
         most_recent_time = 0
-        
+
         for key, entry in self._llm_context_cache._cache.items():
             if f"llm_context_{space_id}" in key:
                 if entry.data.get('timestamp', 0) > most_recent_time:
                     most_recent_time = entry.data.get('timestamp', 0)
                     most_recent_key = key
-        
+
         if most_recent_key:
             return self._llm_context_cache.get(most_recent_key)
-        
+
         return None
 
     # --- MISSING HELPER METHODS IMPLEMENTATION ---
@@ -2448,9 +2448,9 @@ class FacetAwareHUDComponent(Component):
                 if attachment_metadata and len(attachment_metadata) > 0:
                     logger.debug(f"[HUD] Found {len(attachment_metadata)} attachments in facet {facet.facet_id}")
                     return True
-            
+
             # Removed system message scanning for fetch_attachment_result - attachments flow through facets
-                        
+
             # Also check StatusFacets for any attachment information
             for facet in facet_cache.get_facets_by_type(VEILFacetType.STATUS):
                 # Check current_state for attachment information
@@ -2460,9 +2460,9 @@ class FacetAwareHUDComponent(Component):
                     if attachment_metadata and len(attachment_metadata) > 0:
                         logger.debug(f"[HUD] Found {len(attachment_metadata)} attachments in status facet {facet.facet_id}")
                         return True
-                            
+
             return False
-            
+
         except Exception as e:
             logger.error(f"[HUD] Error checking for multimodal content: {e}", exc_info=True)
             return False
@@ -2479,13 +2479,13 @@ class FacetAwareHUDComponent(Component):
         """
         try:
             total_attachments = 0
-            
+
             # Count attachments in EventFacets
             for facet in facet_cache.get_facets_by_type(VEILFacetType.EVENT):
                 attachment_metadata = facet.properties.get('attachment_metadata', [])
                 if attachment_metadata and isinstance(attachment_metadata, list):
                     total_attachments += len(attachment_metadata)
-                        
+
             # Count attachments in StatusFacets
             for facet in facet_cache.get_facets_by_type(VEILFacetType.STATUS):
                 current_state = facet.properties.get('current_state', {})
@@ -2493,10 +2493,10 @@ class FacetAwareHUDComponent(Component):
                     attachment_metadata = current_state.get('attachment_metadata', [])
                     if attachment_metadata and isinstance(attachment_metadata, list):
                         total_attachments += len(attachment_metadata)
-                            
+
             logger.debug(f"[HUD] Counted {total_attachments} total attachments")
             return total_attachments
-            
+
         except Exception as e:
             logger.error(f"[HUD] Error counting multimodal content: {e}", exc_info=True)
             return 0
@@ -2888,7 +2888,7 @@ Use the actual tool name as the XML element name. You can make multiple tool cal
             if current_focus_id != explicit_focus:
                 # This is a focus change - record it
                 self.record_focus_change(focus_context)
-            
+
             self._current_focus = {
                 "focus_element_id": explicit_focus,
                 "focus_source": "explicit_override",

--- a/elements/elements/components/hud/facet_aware_hud_component.py
+++ b/elements/elements/components/hud/facet_aware_hud_component.py
@@ -2511,18 +2511,22 @@ class FacetAwareHUDComponent(Component):
         """
         return """TOOL CALL FORMAT: Use XML format for all tool calls. Do NOT use JSON format.
 
+IMPORTANT: All tool calls must have proper closing tags.
+
 To call tools, use this ultra-concise XML format to send messages:
 
 <msg source="element_name">message</msg>
 
 and this format to use any other tool:
-<tool_name param1="value1" param2="value2" source="element_name">
+<tool_name param1="value1" param2="value2" source="element_name"></tool_name>
 
 Examples:
 <msg source="discord_chat">Hello, world!</msg>
 
-<execute_command command="ls -la" source="Terminal">
+<execute_command command="ls -la" source="Terminal"></execute_command>
 <msg source="zulip_chat">Command executed!</msg>
+
+<get_attachment attachment_id="12345" source="DM_user"></get_attachment>
 
 Use the actual tool name as the XML element name. You can make multiple tool calls in one response. The source parameter specifies which conversation or element to use - choose from the sources listed for each tool type."""
 

--- a/elements/elements/components/messaging/message_action_handler.py
+++ b/elements/elements/components/messaging/message_action_handler.py
@@ -209,6 +209,9 @@ class MessageActionHandler(Component):
             """
             logger.info(f"[{self.owner.id}] get_attachment tool called for attachment_id: {attachment_id}")
             
+            # Convert to string if needed and validate
+            attachment_id = str(attachment_id) if attachment_id is not None else ""
+            
             # Security validation
             if not attachment_id or len(attachment_id.strip()) == 0:
                 return {"success": False, "error": "attachment_id cannot be empty"}

--- a/elements/elements/components/messaging/message_action_handler.py
+++ b/elements/elements/components/messaging/message_action_handler.py
@@ -74,7 +74,6 @@ class MessageActionHandler(Component):
             {"name": "inner_content", "type": "string", "description": "The content of the message to send.", "required": True},
         ]
 
-
         # --- Register msg Tool ---
         @tool_provider.register_tool(
             name="msg",
@@ -182,7 +181,6 @@ class MessageActionHandler(Component):
                 error_msg = f"Exception during direct send_message dispatch: {e}"
                 logger.exception(f"[{self.owner.id}] {error_msg} for req_id: {internal_request_id}")
                 return {"success": False, "error": error_msg, "message_id": None}
-
 
     def _get_message_context(self, use_external_conversation_id: Optional[str] = None) -> Tuple[Optional[str], Optional[str]]:
         """
@@ -397,11 +395,11 @@ class MessageActionHandler(Component):
         """
         # Enhanced input validation
         calling_context = calling_context or {}
-        
+
         if not attachment_id or not isinstance(attachment_id, str) or not attachment_id.strip():
             logger.error(f"[{self.owner.id if self.owner else 'Unknown'}] Invalid attachment_id: {attachment_id}")
             return {"success": False, "error": "attachment_id is required and must be a non-empty string."}
-        
+
         # Sanitize attachment_id to prevent injection issues
         attachment_id = attachment_id.strip()
         if len(attachment_id) > 100:  # Reasonable limit
@@ -426,7 +424,7 @@ class MessageActionHandler(Component):
         if not adapter_id or not isinstance(adapter_id, str):
             logger.error(f"[{self.owner.id if self.owner else 'Unknown'}] Invalid adapter_id: {adapter_id}")
             return {"success": False, "error": "Invalid adapter_id resolved from context."}
-            
+
         if not actual_conversation_id or not isinstance(actual_conversation_id, str):
             logger.error(f"[{self.owner.id if self.owner else 'Unknown'}] Invalid conversation_id: {actual_conversation_id}")
             return {"success": False, "error": "Invalid conversation_id resolved from context."}
@@ -453,14 +451,14 @@ class MessageActionHandler(Component):
                 "calling_loop_id": calling_context.get('loop_component_id') if isinstance(calling_context, dict) else None,
                 "timestamp": time.time()  # Add timestamp for tracking
             }
-            
+
             # Validate payload doesn't have None values where strings are expected
             required_string_fields = ["internal_request_id", "adapter_id", "conversation_id", "attachment_id"]
             for field in required_string_fields:
                 if not payload.get(field) or not isinstance(payload[field], str):
                     logger.error(f"[{self.owner.id if self.owner else 'Unknown'}] Invalid {field} in payload: {payload.get(field)}")
                     return {"success": False, "error": f"Invalid {field} for attachment request."}
-                    
+
         except Exception as e:
             logger.error(f"[{self.owner.id if self.owner else 'Unknown'}] Error creating attachment payload: {e}", exc_info=True)
             return {"success": False, "error": f"Error preparing attachment request: {str(e)}"}
@@ -468,15 +466,15 @@ class MessageActionHandler(Component):
         # Enhanced dispatch with better error context
         try:
             result = await self._dispatch_action("fetch_attachment", payload)
-            
+
             # Add success logging
             if result.get("success"):
                 logger.info(f"[{self.owner.id if self.owner else 'Unknown'}] Successfully initiated attachment fetch for {attachment_id}")
             else:
                 logger.warning(f"[{self.owner.id if self.owner else 'Unknown'}] Attachment fetch dispatch failed for {attachment_id}: {result.get('error', 'Unknown error')}")
-            
+
             return result
-            
+
         except Exception as e:
             logger.error(f"[{self.owner.id if self.owner else 'Unknown'}] Unexpected error dispatching get_attachment_content: {e}", exc_info=True)
             return {"success": False, "error": f"Unexpected error during attachment request: {str(e)}"}

--- a/elements/elements/components/messaging/message_action_handler.py
+++ b/elements/elements/components/messaging/message_action_handler.py
@@ -74,7 +74,6 @@ class MessageActionHandler(Component):
             {"name": "inner_content", "type": "string", "description": "The content of the message to send.", "required": True},
         ]
 
-        # Removed get_attachment_params - attachments flow directly through message_received
 
         # --- Register msg Tool ---
         @tool_provider.register_tool(
@@ -184,7 +183,6 @@ class MessageActionHandler(Component):
                 logger.exception(f"[{self.owner.id}] {error_msg} for req_id: {internal_request_id}")
                 return {"success": False, "error": error_msg, "message_id": None}
 
-        # Removed get_attachment tool - attachments flow directly through message_received
 
     def _get_message_context(self, use_external_conversation_id: Optional[str] = None) -> Tuple[Optional[str], Optional[str]]:
         """

--- a/elements/elements/components/messaging/message_action_handler.py
+++ b/elements/elements/components/messaging/message_action_handler.py
@@ -536,7 +536,7 @@ class MessageActionHandler(Component):
 
         # Enhanced dispatch with better error context
         try:
-            result = await self._dispatch_action("fetch_attachment_content", payload)
+            result = await self._dispatch_action("fetch_attachment", payload)
             
             # Add success logging
             if result.get("success"):

--- a/elements/elements/components/messaging/message_list.py
+++ b/elements/elements/components/messaging/message_list.py
@@ -1525,6 +1525,8 @@ class MessageListComponent(Component):
             return self._handle_edit_message_confirmed(success_content)
         elif action_type in ["add_reaction", "remove_reaction"]:
             return self._handle_reaction_action_confirmed(success_content)
+        elif action_type == "fetch_attachment_content":
+            return self._handle_fetch_attachment_confirmed(success_content)
         else:
             logger.warning(f"[{self.owner.id}] Unknown action_type '{action_type}' in action success. Ignoring.")
             return False
@@ -1545,6 +1547,8 @@ class MessageListComponent(Component):
             return self._handle_message_send_failed(failure_content)
         elif action_type in ["delete_message", "edit_message", "add_reaction", "remove_reaction"]:
             return self._handle_message_action_failed(failure_content)
+        elif action_type == "fetch_attachment_content":
+            return self._handle_fetch_attachment_failed(failure_content)
         else:
             logger.warning(f"[{self.owner.id}] Unknown action_type '{action_type}' in action failure. Ignoring.")
             return False
@@ -1590,6 +1594,26 @@ class MessageListComponent(Component):
         # The actual reaction add/remove should have already been handled by
         # _handle_reaction_added or _handle_reaction_removed
         # This confirmation just means the adapter successfully processed our request
+        return True
+
+    def _handle_fetch_attachment_confirmed(self, success_content: Dict[str, Any]) -> bool:
+        """
+        Handles confirmation of fetch_attachment_content action success.
+        """
+        internal_req_id = success_content.get('internal_request_id')
+        adapter_response_data = success_content.get('adapter_response_data', {})
+        logger.info(f"[{self.owner.id}] Fetch attachment confirmed for req_id: {internal_req_id}")
+        # The actual attachment content should be handled by the tool that requested it
+        return True
+
+    def _handle_fetch_attachment_failed(self, failure_content: Dict[str, Any]) -> bool:
+        """
+        Handles failure of fetch_attachment_content action.
+        """
+        internal_req_id = failure_content.get('internal_request_id')
+        error_msg = failure_content.get('error_message')
+        logger.warning(f"[{self.owner.id}] Fetch attachment failed for req_id: {internal_req_id}. Error: {error_msg}")
+        # The tool that requested the attachment should handle the failure
         return True
 
     def _handle_message_action_failed(self, failure_content: Dict[str, Any]) -> bool:

--- a/elements/elements/components/messaging/message_list.py
+++ b/elements/elements/components/messaging/message_list.py
@@ -37,7 +37,7 @@ class MessageListComponent(Component):
         "connectome_message_updated",         # Use Connectome-defined types for delete/edit
         "connectome_reaction_added",          # For handling added reactions
         "connectome_reaction_removed",        # For handling removed reactions
-        # Removed attachment_content_available - attachments flow directly through message_received
+        # attachment_content_available removed - attachments now flow through message_received events
         "connectome_action_success",          # NEW: Generic action success (replaces specific events)
         "connectome_action_failure",          # NEW: Generic action failure (replaces specific events)
     ]
@@ -96,7 +96,7 @@ class MessageListComponent(Component):
                 self._handle_reaction_added(actual_content_payload)
             elif event_type == "connectome_reaction_removed":
                 self._handle_reaction_removed(actual_content_payload)
-            # Removed attachment_content_available handler - attachments flow directly
+            # attachment_content_available handler removed - attachments flow through message_received
             elif event_type == "connectome_action_success":
                 self._handle_action_success(actual_content_payload)
             elif event_type == "connectome_action_failure":
@@ -816,7 +816,7 @@ class MessageListComponent(Component):
             "message_map_size": map_size
         }
 
-    # Removed _handle_attachment_content_available - attachments flow directly through message_received
+    # _handle_attachment_content_available removed - attachments now flow through message_received events
 
     # --- NEW: Method for adding a pending outgoing message ---
     def add_pending_message(self,

--- a/elements/elements/components/messaging/message_list.py
+++ b/elements/elements/components/messaging/message_list.py
@@ -1525,7 +1525,7 @@ class MessageListComponent(Component):
             return self._handle_edit_message_confirmed(success_content)
         elif action_type in ["add_reaction", "remove_reaction"]:
             return self._handle_reaction_action_confirmed(success_content)
-        elif action_type == "fetch_attachment_content":
+        elif action_type == "fetch_attachment":
             return self._handle_fetch_attachment_confirmed(success_content)
         else:
             logger.warning(f"[{self.owner.id}] Unknown action_type '{action_type}' in action success. Ignoring.")
@@ -1547,7 +1547,7 @@ class MessageListComponent(Component):
             return self._handle_message_send_failed(failure_content)
         elif action_type in ["delete_message", "edit_message", "add_reaction", "remove_reaction"]:
             return self._handle_message_action_failed(failure_content)
-        elif action_type == "fetch_attachment_content":
+        elif action_type == "fetch_attachment":
             return self._handle_fetch_attachment_failed(failure_content)
         else:
             logger.warning(f"[{self.owner.id}] Unknown action_type '{action_type}' in action failure. Ignoring.")
@@ -1598,7 +1598,7 @@ class MessageListComponent(Component):
 
     def _handle_fetch_attachment_confirmed(self, success_content: Dict[str, Any]) -> bool:
         """
-        Handles confirmation of fetch_attachment_content action success.
+        Handles confirmation of fetch_attachment action success.
         """
         internal_req_id = success_content.get('internal_request_id')
         adapter_response_data = success_content.get('adapter_response_data', {})
@@ -1608,7 +1608,7 @@ class MessageListComponent(Component):
 
     def _handle_fetch_attachment_failed(self, failure_content: Dict[str, Any]) -> bool:
         """
-        Handles failure of fetch_attachment_content action.
+        Handles failure of fetch_attachment action.
         """
         internal_req_id = failure_content.get('internal_request_id')
         error_msg = failure_content.get('error_message')

--- a/elements/elements/components/messaging/message_list_veil_producer.py
+++ b/elements/elements/components/messaging/message_list_veil_producer.py
@@ -153,10 +153,7 @@ class MessageListVeilProducer(VeilProducer):
                     "conversation_name": conversation_metadata.get("conversation_name"),
                     "error_details": msg_data.get('error_details', None),
                     "is_from_current_agent": msg_data.get('is_from_current_agent', False),  # For HUD rendering decisions
-                    VEIL_ATTACHMENT_METADATA_PROP: [
-                        {k: v for k, v in att.items() if k != 'content'}
-                        for att in processed_attachments_from_mlc
-                    ]
+                    VEIL_ATTACHMENT_METADATA_PROP: processed_attachments_from_mlc  # Include full attachment data including content
                 },
                 "children": [] # Initialize, may add attachment content nodes later
             }
@@ -371,10 +368,7 @@ class MessageListVeilProducer(VeilProducer):
                     "is_from_current_agent": msg_data.get('is_from_current_agent', False),  # For HUD rendering decisions
                     "is_internal_origin": msg_data.get('is_internal_origin', False),  # NEW: Track message origin for synthetic response logic
                     "error_details": msg_data.get('error_details', None),
-                    "attachment_metadata": [
-                        {k: v for k, v in att.items() if k != 'content'}
-                        for att in msg_data.get('attachments', [])
-                    ]
+                    "attachment_metadata": msg_data.get('attachments', [])  # Include full attachment data including content
                 })
 
                 facet_operations.append(FacetOperationBuilder.add_facet(message_facet))

--- a/host/config.py
+++ b/host/config.py
@@ -132,7 +132,7 @@ def load_settings() -> HostSettings:
     # Try to manually load .env file first
     try:
         from dotenv import load_dotenv
-        env_loaded = load_dotenv('.env', override=True)
+        env_loaded = load_dotenv('.env', override=False)
         logger.info(f"Manual .env loading result: {env_loaded}")
     except Exception as e:
         logger.warning(f"Failed to manually load .env file: {e}")

--- a/host/modules/inspector/data_collector.py
+++ b/host/modules/inspector/data_collector.py
@@ -1992,8 +1992,16 @@ class InspectorDataCollector:
                 content_type = "application/json"
             elif render_format == "agent_context":
                 # Return the actual agent context with multimodal integration as sent to LLM
-                agent_context = await hud_component.get_agent_context_via_compression_engine(hud_options)
-                rendered_content = agent_context
+                # First try to get cached LLM context (the ground truth of what agent received)
+                cached_context = hud_component.get_cached_llm_context()
+                if cached_context and cached_context.get('messages'):
+                    logger.debug(f"Using cached LLM context from {cached_context.get('timestamp')} for inspector")
+                    rendered_content = cached_context['messages']
+                else:
+                    # Fallback to re-rendering if no cache available
+                    logger.debug("No cached LLM context available, falling back to re-rendering")
+                    agent_context = await hud_component.get_agent_context_via_compression_engine(hud_options)
+                    rendered_content = agent_context
                 content_type = "application/json"
             elif render_format == "markdown":
                 # Format as markdown

--- a/host/modules/inspector/data_collector.py
+++ b/host/modules/inspector/data_collector.py
@@ -1893,7 +1893,7 @@ class InspectorDataCollector:
         Args:
             space_id: The ID of the space to render
             options: Rendering options including:
-                - format: "text" (default), "markdown", "json_messages"
+                - format: "text" (default), "markdown", "json_messages", "agent_context"
                 - include_tools: Include tool/ambient facets (default: True)
                 - include_system: Include system messages (default: True)
                 - max_turns: Limit number of turns to render
@@ -1989,6 +1989,11 @@ class InspectorDataCollector:
             if render_format == "json_messages":
                 # Return the raw message list
                 rendered_content = turn_messages
+                content_type = "application/json"
+            elif render_format == "agent_context":
+                # Return the actual agent context with multimodal integration as sent to LLM
+                agent_context = await hud_component.get_agent_context_via_compression_engine(hud_options)
+                rendered_content = agent_context
                 content_type = "application/json"
             elif render_format == "markdown":
                 # Format as markdown

--- a/host/modules/inspector/inspector_server.py
+++ b/host/modules/inspector/inspector_server.py
@@ -528,7 +528,7 @@ class InspectorServer:
             content_type = metadata.get("content_type", "text/plain")
             
             # For JSON format, return as JSON response
-            if metadata.get("format") == "json_messages":
+            if metadata.get("format") in ["json_messages", "agent_context"]:
                 return self._json_response(content)
             
             # For text/markdown formats, return as plain text response

--- a/host/routing/external_event_router.py
+++ b/host/routing/external_event_router.py
@@ -191,8 +191,7 @@ class ExternalEventRouter:
                     await self._handle_history_fetched(source_adapter_id, adapter_data)
                 elif event_type_from_adapter == "connectome_attachment_received":
                     await self._handle_attachment_received(source_adapter_id, payload.get("conversation_id"), payload)
-                elif event_type_from_adapter == "connectome_attachment_data_received":
-                    await self._handle_attachment_data_received(source_adapter_id, adapter_data)
+                # Removed connectome_attachment_data_received handling - attachments flow directly through message_received
                 # --- NEW: Handle Generic Action Confirmations/Failures ---
                 elif event_type_from_adapter == "adapter_action_success": # Generic success for any action
                     await self._handle_action_success_ack(source_adapter_id, adapter_data)
@@ -205,10 +204,7 @@ class ExternalEventRouter:
                 elif event_type_from_adapter == "adapter_send_failure_ack": # Legacy - redirect to generic handler
                     logger.warning(f"Received legacy 'adapter_send_failure_ack' event. Redirecting to generic handler.")
                     await self._handle_action_failure_ack(source_adapter_id, adapter_data)
-                elif event_type_from_adapter == "fetch_attachment":
-                    logger.info(f"Handling fetch_attachment event from adapter '{source_adapter_id}'")
-                    # This might be treated as an action response rather than an event
-                    # For now, just log it - actual attachment content should come via action success/failure
+                # Removed fetch_attachment event handling - not needed with simplified attachment flow
                 else:
                     logger.warning(f"ExternalEventRouter: Unhandled event type '{event_type_from_adapter}' from adapter '{source_adapter_id}'. Data: {adapter_data}")
                     span.set_attribute("routing.status", "unhandled_event_type")
@@ -1121,81 +1117,7 @@ class ExternalEventRouter:
         except Exception as e:
             logger.error(f"Error routing connectome_attachment_received event: {e}", exc_info=True)
 
-    # --- NEW HANDLER for Fetched Attachment Data ---
-    async def _handle_attachment_data_received(self, source_adapter_id: str, adapter_data_with_content: Dict[str, Any]):
-        """
-        Handles an event from ActivityClient containing the actual fetched content of an attachment.
-        Uses unified agent-based routing for consistency with all message events.
-
-        Args:
-            source_adapter_id: The adapter that fetched the data.
-            adapter_data_with_content: The payload from ActivityClient. Expected to contain:
-                - conversation_id: ID of the original conversation.
-                - original_message_id_external: ID of the message this attachment belongs to.
-                - attachment_id: ID of the attachment.
-                - filename: Name of the file.
-                - content_type: MIME type of the content.
-                - content: The actual attachment content (e.g., bytes or base64 string).
-                - adapter_data: Crucially, this nested dict must contain routing info
-                                including adapter_name for agent identification.
-        """
-        conversation_id = adapter_data_with_content.get("conversation_id")
-        original_message_id = adapter_data_with_content.get("original_message_id_external")
-        attachment_id = adapter_data_with_content.get("attachment_id")
-
-        logger.info(f"Handling 'connectome_attachment_data_received' for conv '{conversation_id}', msg '{original_message_id}', attachment '{attachment_id}' from {source_adapter_id}.")
-
-        if not all([conversation_id, original_message_id, attachment_id]):
-            logger.error(f"_handle_attachment_data_received: Missing key identifiers in payload. Data: {adapter_data_with_content}")
-            return
-
-        # This nested adapter_data is crucial for routing to the correct agent
-        routing_adapter_data = adapter_data_with_content.get("adapter_data")
-        if not isinstance(routing_adapter_data, dict):
-            logger.error(f"_handle_attachment_data_received: 'adapter_data' for routing is missing or not a dict in payload. Data: {adapter_data_with_content}")
-            return
-
-        # Extract recipient agent ID like _handle_direct_message does
-        adapter_name = routing_adapter_data.get("adapter_name")
-        agent_id = self._get_agent_id_by_alias(adapter_name)
-        routing_adapter_data["recipient_connectome_agent_id"] = agent_id
-
-        # Use unified InnerSpace routing
-        target_inner_space = await self._find_target_inner_space_for_agent(routing_adapter_data)
-        if not target_inner_space:
-            logger.error(f"_handle_attachment_data_received: Target InnerSpace not found for conv '{conversation_id}'. Attachment data for '{attachment_id}' cannot be delivered.")
-            return
-
-        # Prepare payload for the internal event to be stored in the space
-        internal_event_payload = {
-            "source_adapter_id": source_adapter_id,
-            "external_conversation_id": conversation_id,
-            "original_message_id_external": original_message_id,
-            "attachment_id": attachment_id,
-            "filename": adapter_data_with_content.get("filename"),
-            "content_type": adapter_data_with_content.get("content_type"),
-            "content": adapter_data_with_content.get("content"),
-            "status": "content_available",
-            "timestamp": adapter_data_with_content.get("timestamp", time.time())
-        }
-
-        # Determine if this is a DM for proper target element ID generation
-        is_dm = routing_adapter_data.get("is_direct_message", False)
-        target_element_id = self._generate_target_element_id(source_adapter_id, conversation_id, is_dm, target_inner_space)
-
-        connectome_internal_event = {
-            "event_type": "attachment_content_available",
-            "target_element_id": target_element_id,
-            "is_replayable": True,  # Attachment content should be replayed for message state restoration
-            "payload": internal_event_payload
-        }
-
-        timeline_context = await self._construct_timeline_context_for_space(target_inner_space)
-        try:
-            target_inner_space.receive_event(connectome_internal_event, timeline_context)
-            logger.info(f"Routed 'attachment_content_available' for attachment '{attachment_id}' to InnerSpace '{target_inner_space.id}'.")
-        except Exception as e:
-            logger.error(f"Error routing 'attachment_content_available' event to InnerSpace '{target_inner_space.id}': {e}", exc_info=True)
+    # Removed _handle_attachment_data_received - attachments flow directly through message_received events
 
     def _generate_target_element_id(self, source_adapter_id: str, conversation_id: str, is_dm: bool, target_space: Optional[Space] = None) -> str:
         """

--- a/host/routing/external_event_router.py
+++ b/host/routing/external_event_router.py
@@ -205,6 +205,10 @@ class ExternalEventRouter:
                 elif event_type_from_adapter == "adapter_send_failure_ack": # Legacy - redirect to generic handler
                     logger.warning(f"Received legacy 'adapter_send_failure_ack' event. Redirecting to generic handler.")
                     await self._handle_action_failure_ack(source_adapter_id, adapter_data)
+                elif event_type_from_adapter == "fetch_attachment_content":
+                    logger.info(f"Handling fetch_attachment_content event from adapter '{source_adapter_id}'")
+                    # This might be treated as an action response rather than an event
+                    # For now, just log it - actual attachment content should come via action success/failure
                 else:
                     logger.warning(f"ExternalEventRouter: Unhandled event type '{event_type_from_adapter}' from adapter '{source_adapter_id}'. Data: {adapter_data}")
                     span.set_attribute("routing.status", "unhandled_event_type")

--- a/host/routing/external_event_router.py
+++ b/host/routing/external_event_router.py
@@ -191,7 +191,7 @@ class ExternalEventRouter:
                     await self._handle_history_fetched(source_adapter_id, adapter_data)
                 elif event_type_from_adapter == "connectome_attachment_received":
                     await self._handle_attachment_received(source_adapter_id, payload.get("conversation_id"), payload)
-                # Removed connectome_attachment_data_received handling - attachments flow directly through message_received
+                # connectome_attachment_data_received handling removed - attachments now flow through message_received
                 # --- NEW: Handle Generic Action Confirmations/Failures ---
                 elif event_type_from_adapter == "adapter_action_success": # Generic success for any action
                     await self._handle_action_success_ack(source_adapter_id, adapter_data)
@@ -204,7 +204,7 @@ class ExternalEventRouter:
                 elif event_type_from_adapter == "adapter_send_failure_ack": # Legacy - redirect to generic handler
                     logger.warning(f"Received legacy 'adapter_send_failure_ack' event. Redirecting to generic handler.")
                     await self._handle_action_failure_ack(source_adapter_id, adapter_data)
-                # Removed fetch_attachment event handling - not needed with simplified attachment flow
+                # fetch_attachment event handling removed - attachments use simplified flow through message_received
                 else:
                     logger.warning(f"ExternalEventRouter: Unhandled event type '{event_type_from_adapter}' from adapter '{source_adapter_id}'. Data: {adapter_data}")
                     span.set_attribute("routing.status", "unhandled_event_type")
@@ -1117,7 +1117,7 @@ class ExternalEventRouter:
         except Exception as e:
             logger.error(f"Error routing connectome_attachment_received event: {e}", exc_info=True)
 
-    # Removed _handle_attachment_data_received - attachments flow directly through message_received events
+    # _handle_attachment_data_received method removed - attachments now flow through message_received events
 
     def _generate_target_element_id(self, source_adapter_id: str, conversation_id: str, is_dm: bool, target_space: Optional[Space] = None) -> str:
         """

--- a/host/routing/external_event_router.py
+++ b/host/routing/external_event_router.py
@@ -205,8 +205,8 @@ class ExternalEventRouter:
                 elif event_type_from_adapter == "adapter_send_failure_ack": # Legacy - redirect to generic handler
                     logger.warning(f"Received legacy 'adapter_send_failure_ack' event. Redirecting to generic handler.")
                     await self._handle_action_failure_ack(source_adapter_id, adapter_data)
-                elif event_type_from_adapter == "fetch_attachment_content":
-                    logger.info(f"Handling fetch_attachment_content event from adapter '{source_adapter_id}'")
+                elif event_type_from_adapter == "fetch_attachment":
+                    logger.info(f"Handling fetch_attachment event from adapter '{source_adapter_id}'")
                     # This might be treated as an action response rather than an event
                     # For now, just log it - actual attachment content should come via action success/failure
                 else:
@@ -1313,7 +1313,7 @@ class ExternalEventRouter:
                 "limit": payload.get("limit", 100)
             })
 
-        elif action_type == "fetch_attachment_content":
+        elif action_type == "fetch_attachment":
             clean_payload.update({
                 "conversation_id": conversation_id,
                 "attachment_id": payload.get("attachment_id")


### PR DESCRIPTION
This restores (and completes) attachments functionality, including sending them to the LLM. 

Additionally:

- Adds an inspector feature to view the agent's entire context (no UI integration), not just the sanitized hud
- Flips dotenv override param to false, because Claudes really like to set log level to debug through an env param
- Amends tool instructions to be closer to what the system actually expects

Unsure about:
- The multimodal detection function and attachment filler operates on the full facet cache, not the processed cache as previously. This is maybe too much? The processed_facets cache does not have attachment content, though.
- How this works, and how is it supposed to work, with the compression engine.

Known issues:
- Anthropic api seems to cache attachments. See this image where the agent is reacting to an entirely different image. Inspector, OTEL, and even Wireshark confirm that the agent receives the *correct* base64-encoded image.
- The `get_attachment` tool is nonfunctional. In fact, all get tools are nonfunctional, as they do not currently have a mechanism to return data back to be readable by agent. These mechanisms *can* be jury-rigged, but perhaps something better should exist.

Advise using squash on merge.


<img width="588" height="384" alt="image" src="https://github.com/user-attachments/assets/c0da27fe-963c-46b7-a8fd-697e0719b1d5" />
