### PR TITLE
Typing notifications

### DIFF
--- a/elements/elements/components/activity_status_component.py
+++ b/elements/elements/components/activity_status_component.py
@@ -7,10 +7,13 @@ import logging
 import time
 from typing import Dict, Any, Optional, Callable
 
+from opentelemetry import trace
+
 from ..base import Component
 from elements.component_registry import register_component
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 @register_component
@@ -54,43 +57,57 @@ class ActivityStatusComponent(Component):
         Returns:
             Dictionary with success status and any relevant info
         """
-        if not self._outgoing_action_callback:
-            error_msg = "Cannot send typing indicator: No outgoing action callback set"
-            logger.error(f"[{self.owner.id}] {error_msg}")
-            return {"success": False, "error": error_msg}
+        with tracer.start_as_current_span("activity_status.handle_typing_indicator") as span:
+            span.set_attribute("adapter_id", adapter_id)
+            span.set_attribute("conversation_id", conversation_id)
+            span.set_attribute("is_typing", is_typing)
+            span.set_attribute("element_id", self.owner.id)
 
-        # Create internal request ID for tracking
-        internal_request_id = f"typing_{adapter_id}_{conversation_id}_{int(time.time())}"
-
-        # Create action request following the same pattern as tool calls
-        action_request = {
-            "action_type": "send_typing_indicator",
-            "target_module": "ActivityClient",
-            "payload": {
-                "action_type": "send_typing_indicator",
-                "adapter_id": adapter_id,
-                "conversation_id": conversation_id,
-                "is_typing": is_typing,
-                "internal_request_id": internal_request_id,
-                "requesting_element_id": self.owner.id
-            }
-        }
-
-        try:
-            logger.debug(f"[{self.owner.id}] Sending typing indicator ({is_typing}) for {adapter_id}/{conversation_id}")
-
-            # Send through the unified action system
-            dispatch_result = await self._outgoing_action_callback(action_request)
-
-            if dispatch_result and dispatch_result.get("success"):
-                logger.debug(f"[{self.owner.id}] Typing indicator successfully dispatched for req_id: {internal_request_id}")
-                return {"success": True, "internal_request_id": internal_request_id}
-            else:
-                error_msg = f"Failed to dispatch typing indicator. Result: {dispatch_result}"
-                logger.error(f"[{self.owner.id}] {error_msg} for req_id: {internal_request_id}")
+            if not self._outgoing_action_callback:
+                error_msg = "Cannot send typing indicator: No outgoing action callback set"
+                logger.error(f"[{self.owner.id}] {error_msg}")
+                span.set_status(trace.Status(trace.StatusCode.ERROR, error_msg))
                 return {"success": False, "error": error_msg}
 
-        except Exception as e:
-            error_msg = f"Error dispatching typing indicator: {e}"
-            logger.error(f"[{self.owner.id}] {error_msg}", exc_info=True)
-            return {"success": False, "error": error_msg}
+            # Create internal request ID for tracking
+            internal_request_id = f"typing_{adapter_id}_{conversation_id}_{int(time.time())}"
+            span.set_attribute("internal_request_id", internal_request_id)
+
+            # Create action request following the same pattern as tool calls
+            action_request = {
+                "action_type": "send_typing_indicator",
+                "target_module": "ActivityClient",
+                "payload": {
+                    "action_type": "send_typing_indicator",
+                    "adapter_id": adapter_id,
+                    "conversation_id": conversation_id,
+                    "is_typing": is_typing,
+                    "internal_request_id": internal_request_id,
+                    "requesting_element_id": self.owner.id
+                }
+            }
+
+            try:
+                logger.debug(f"[{self.owner.id}] Sending typing indicator ({is_typing}) for {adapter_id}/{conversation_id}")
+                span.add_event("dispatching_typing_indicator")
+
+                # Send through the unified action system
+                dispatch_result = await self._outgoing_action_callback(action_request)
+                span.add_event("dispatch_completed")
+
+                if dispatch_result and dispatch_result.get("success"):
+                    logger.debug(f"[{self.owner.id}] Typing indicator successfully dispatched for req_id: {internal_request_id}")
+                    span.set_status(trace.Status(trace.StatusCode.OK))
+                    return {"success": True, "internal_request_id": internal_request_id}
+                else:
+                    error_msg = f"Failed to dispatch typing indicator. Result: {dispatch_result}"
+                    logger.error(f"[{self.owner.id}] {error_msg} for req_id: {internal_request_id}")
+                    span.set_status(trace.Status(trace.StatusCode.ERROR, error_msg))
+                    return {"success": False, "error": error_msg}
+
+            except Exception as e:
+                error_msg = f"Error dispatching typing indicator: {e}"
+                logger.error(f"[{self.owner.id}] {error_msg}", exc_info=True)
+                span.record_exception(e)
+                span.set_status(trace.Status(trace.StatusCode.ERROR, error_msg))
+                return {"success": False, "error": error_msg}

--- a/elements/elements/components/activity_status_component.py
+++ b/elements/elements/components/activity_status_component.py
@@ -1,0 +1,96 @@
+"""
+Activity Status Component
+
+Handles activity status indicators like typing notifications through the unified component architecture.
+"""
+import logging
+import time
+from typing import Dict, Any, Optional, Callable
+
+from ..base import Component
+from elements.component_registry import register_component
+
+logger = logging.getLogger(__name__)
+
+
+@register_component
+class ActivityStatusComponent(Component):
+    """
+    Component that handles activity status indicators (typing, presence, etc.)
+    through the standard component architecture and outgoing action callback.
+    """
+
+    COMPONENT_TYPE = "ActivityStatusComponent"
+    DEPENDENCIES = []
+    HANDLED_EVENT_TYPES = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._outgoing_action_callback: Optional[Callable] = None
+
+    def _on_initialize(self) -> None:
+        """Initialize the activity status component."""
+        logger.debug(f"ActivityStatusComponent {self.id} initialized")
+
+    def set_outgoing_action_callback(self, callback: Callable) -> None:
+        """
+        Set the callback for outgoing actions (typically ExternalEventRouter.handle_outgoing_action).
+
+        Args:
+            callback: Function to call for outgoing actions
+        """
+        self._outgoing_action_callback = callback
+        logger.debug(f"ActivityStatusComponent {self.id}: Outgoing action callback set")
+
+    async def handle_typing_indicator(self, adapter_id: str, conversation_id: str, is_typing: bool = True) -> Dict[str, Any]:
+        """
+        Send a typing indicator through the unified action system.
+
+        Args:
+            adapter_id: ID of the adapter to send through
+            conversation_id: ID of the conversation/chat
+            is_typing: Whether typing is active (True) or not (False)
+
+        Returns:
+            Dictionary with success status and any relevant info
+        """
+        if not self._outgoing_action_callback:
+            error_msg = "Cannot send typing indicator: No outgoing action callback set"
+            logger.error(f"[{self.owner.id}] {error_msg}")
+            return {"success": False, "error": error_msg}
+
+        # Create internal request ID for tracking
+        internal_request_id = f"typing_{adapter_id}_{conversation_id}_{int(time.time())}"
+
+        # Create action request following the same pattern as tool calls
+        action_request = {
+            "action_type": "send_typing_indicator",
+            "target_module": "ActivityClient",
+            "payload": {
+                "action_type": "send_typing_indicator",
+                "adapter_id": adapter_id,
+                "conversation_id": conversation_id,
+                "is_typing": is_typing,
+                "internal_request_id": internal_request_id,
+                "requesting_element_id": self.owner.id
+            }
+        }
+
+        try:
+            logger.debug(f"[{self.owner.id}] Sending typing indicator ({is_typing}) for {adapter_id}/{conversation_id}")
+
+            # Send through the unified action system
+            dispatch_result = await self._outgoing_action_callback(action_request)
+
+            if dispatch_result and dispatch_result.get("success"):
+                logger.debug(f"[{self.owner.id}] Typing indicator successfully dispatched for req_id: {internal_request_id}")
+                return {"success": True, "internal_request_id": internal_request_id}
+            else:
+                error_msg = f"Failed to dispatch typing indicator. Result: {dispatch_result}"
+                logger.error(f"[{self.owner.id}] {error_msg} for req_id: {internal_request_id}")
+                return {"success": False, "error": error_msg}
+
+        except Exception as e:
+            error_msg = f"Error dispatching typing indicator: {e}"
+            logger.error(f"[{self.owner.id}] {error_msg}", exc_info=True)
+            return {"success": False, "error": error_msg}

--- a/elements/elements/components/agent_loop/base_agent_loop_component.py
+++ b/elements/elements/components/agent_loop/base_agent_loop_component.py
@@ -170,33 +170,6 @@ class BaseAgentLoopComponent(Component):
             focus_context = inner_payload.get('focus_context', {})
             focus_element_id = focus_context.get('focus_element_id')
             
-            # NEW: Send initial typing indicator when activation starts
-            try:
-                if focus_element_id:
-                    # Try to extract adapter and chat IDs for immediate typing
-                    element = self.parent_inner_space.get_element_by_id(focus_element_id)
-                    if element:
-                        chat_id = getattr(element, 'external_conversation_id', None) or \
-                                 getattr(element, 'conversation_id', None)
-                        adapter_id = getattr(element, 'adapter_id', None)
-
-                        if not adapter_id or not chat_id:
-                            parent_space = getattr(element, 'get_parent_object', lambda: None)()
-                            if parent_space:
-                                chat_id = chat_id or getattr(parent_space, 'external_conversation_id', None)
-                                adapter_id = adapter_id or getattr(parent_space, 'adapter_id', None)
-
-                        if adapter_id and chat_id:
-                            # Get ActivityStatusComponent from inner space
-                            activity_status_component = self.parent_inner_space.get_component_by_type("ActivityStatusComponent")
-                            if activity_status_component:
-                                # Send initial typing indicator through component
-                                await activity_status_component.handle_typing_indicator(adapter_id, chat_id, is_typing=True)
-                                logger.debug(f"[{self.agent_loop_name}] Sent initial typing indicator for {adapter_id}/{chat_id}")
-                            else:
-                                logger.debug(f"[{self.agent_loop_name}] No ActivityStatusComponent found for typing indicator")
-            except Exception as e:
-                logger.debug(f"[{self.agent_loop_name}] Could not send initial typing indicator: {e}")
 
             if focus_element_id:
                 logger.info(f"[{self.agent_loop_name}] Activation with focused context on element: {focus_element_id}")
@@ -332,11 +305,96 @@ class BaseAgentLoopComponent(Component):
     def get_active_completions(self) -> Dict[str, Dict[str, Any]]:
         """
         Get all currently active LLM completions being tracked.
-        
+
         Returns:
             Dictionary of completion_id -> context for all active completions
         """
         return self._active_completions.copy()
+
+    def _extract_typing_context_from_focus(self, focus_context: Optional[Dict[str, Any]]) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """
+        Extract adapter ID, chat ID, and focus element ID from focus context for typing notifications.
+
+        This centralizes the logic for finding typing context information that was duplicated
+        across agent loop implementations.
+
+        Args:
+            focus_context: Focus context from activation event
+
+        Returns:
+            Tuple of (adapter_id, chat_id, focus_element_id) or (None, None, None) if not found
+        """
+        try:
+            if not focus_context:
+                return None, None, None
+
+            focus_element_id = focus_context.get('focus_element_id')
+            if not focus_element_id:
+                return None, None, None
+
+            # Get the element to find its conversation ID
+            element = self.parent_inner_space.get_element_by_id(focus_element_id)
+            if not element:
+                return None, None, focus_element_id
+
+            # Look for conversation ID in element or its parent
+            chat_id = getattr(element, 'external_conversation_id', None) or \
+                     getattr(element, 'conversation_id', None)
+            adapter_id = getattr(element, 'adapter_id', None)
+
+            # If not on element, check parent space
+            if not adapter_id or not chat_id:
+                parent_space = getattr(element, 'get_parent_object', lambda: None)()
+                if parent_space:
+                    chat_id = chat_id or getattr(parent_space, 'external_conversation_id', None)
+                    adapter_id = adapter_id or getattr(parent_space, 'adapter_id', None)
+
+            return adapter_id, chat_id, focus_element_id
+
+        except Exception as e:
+            logger.warning(f"[{self.agent_loop_name}] Error extracting typing context: {e}")
+            return None, None, None
+
+    async def _start_typing_notifications(self, focus_context: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        """
+        Start typing notifications for this agent loop cycle.
+
+        This method combines the initial typing indicator and completion tracking setup
+        that was duplicated across agent loop implementations.
+
+        Args:
+            focus_context: Optional focus context from activation event
+
+        Returns:
+            Completion ID if tracking was started, None otherwise
+        """
+        try:
+            adapter_id, chat_id, focus_element_id = self._extract_typing_context_from_focus(focus_context)
+
+            if not adapter_id or not chat_id:
+                logger.debug(f"[{self.agent_loop_name}] Could not extract typing context - adapter_id: {adapter_id}, chat_id: {chat_id}")
+                return None
+
+            # Send initial typing indicator through ActivityStatusComponent
+            try:
+                activity_status_component = self.parent_inner_space.get_component_by_type("ActivityStatusComponent")
+                if activity_status_component:
+                    await activity_status_component.handle_typing_indicator(adapter_id, chat_id, is_typing=True)
+                    logger.debug(f"[{self.agent_loop_name}] Sent initial typing indicator for {adapter_id}/{chat_id}")
+                else:
+                    logger.debug(f"[{self.agent_loop_name}] No ActivityStatusComponent found for typing indicator")
+            except Exception as e:
+                logger.debug(f"[{self.agent_loop_name}] Could not send initial typing indicator: {e}")
+
+            # Start completion tracking
+            completion_id = self.start_completion_tracking(adapter_id, chat_id, focus_element_id)
+            logger.debug(f"[{self.agent_loop_name}] Started typing tracking for {adapter_id}/{chat_id}")
+
+            return completion_id
+
+        except Exception as e:
+            logger.warning(f"[{self.agent_loop_name}] Error starting typing notifications: {e}")
+            return None
 
     def _resolve_prefix_to_element_id(self, prefix: str) -> Optional[str]:
         """

--- a/elements/elements/components/agent_loop/base_agent_loop_component.py
+++ b/elements/elements/components/agent_loop/base_agent_loop_component.py
@@ -172,26 +172,29 @@ class BaseAgentLoopComponent(Component):
             
             # NEW: Send initial typing indicator when activation starts
             try:
-                from elements.space_registry import get_space_registry
-                space_registry = get_space_registry()
-                if space_registry and focus_element_id:
+                if focus_element_id:
                     # Try to extract adapter and chat IDs for immediate typing
                     element = self.parent_inner_space.get_element_by_id(focus_element_id)
                     if element:
                         chat_id = getattr(element, 'external_conversation_id', None) or \
                                  getattr(element, 'conversation_id', None)
                         adapter_id = getattr(element, 'adapter_id', None)
-                        
+
                         if not adapter_id or not chat_id:
                             parent_space = getattr(element, 'get_parent_object', lambda: None)()
                             if parent_space:
                                 chat_id = chat_id or getattr(parent_space, 'external_conversation_id', None)
                                 adapter_id = adapter_id or getattr(parent_space, 'adapter_id', None)
-                        
+
                         if adapter_id and chat_id:
-                            # Send initial typing indicator
-                            space_registry.send_typing_indicator(adapter_id, chat_id, is_typing=True)
-                            logger.debug(f"[{self.agent_loop_name}] Sent initial typing indicator for {adapter_id}/{chat_id}")
+                            # Get ActivityStatusComponent from inner space
+                            activity_status_component = self.parent_inner_space.get_component_by_type("ActivityStatusComponent")
+                            if activity_status_component:
+                                # Send initial typing indicator through component
+                                await activity_status_component.handle_typing_indicator(adapter_id, chat_id, is_typing=True)
+                                logger.debug(f"[{self.agent_loop_name}] Sent initial typing indicator for {adapter_id}/{chat_id}")
+                            else:
+                                logger.debug(f"[{self.agent_loop_name}] No ActivityStatusComponent found for typing indicator")
             except Exception as e:
                 logger.debug(f"[{self.agent_loop_name}] Could not send initial typing indicator: {e}")
 

--- a/elements/elements/components/agent_loop/base_agent_loop_component.py
+++ b/elements/elements/components/agent_loop/base_agent_loop_component.py
@@ -4,6 +4,8 @@ Defines the abstract base class for agent cognitive cycles.
 """
 import logging
 import asyncio
+import uuid
+import time
 from typing import Dict, Any, Optional, TYPE_CHECKING, List, Set, Type, Union
 from datetime import datetime
 
@@ -81,6 +83,9 @@ class BaseAgentLoopComponent(Component):
 
         # NEW: Cooperative cancellation confirmation event
         self._cancel_event: asyncio.Event = asyncio.Event()
+        
+        # NEW: Track active LLM completions for typing notifications
+        self._active_completions: Dict[str, Dict[str, Any]] = {}  # completion_id -> context
 
         # Convenience accessors, assuming parent_inner_space is correctly typed and populated
         self._llm_provider: Optional['LLMProvider'] = self.parent_inner_space._llm_provider
@@ -164,6 +169,31 @@ class BaseAgentLoopComponent(Component):
             inner_payload = event_payload.get('payload', {})
             focus_context = inner_payload.get('focus_context', {})
             focus_element_id = focus_context.get('focus_element_id')
+            
+            # NEW: Send initial typing indicator when activation starts
+            try:
+                from elements.space_registry import get_space_registry
+                space_registry = get_space_registry()
+                if space_registry and focus_element_id:
+                    # Try to extract adapter and chat IDs for immediate typing
+                    element = self.parent_inner_space.get_element_by_id(focus_element_id)
+                    if element:
+                        chat_id = getattr(element, 'external_conversation_id', None) or \
+                                 getattr(element, 'conversation_id', None)
+                        adapter_id = getattr(element, 'adapter_id', None)
+                        
+                        if not adapter_id or not chat_id:
+                            parent_space = getattr(element, 'get_parent_object', lambda: None)()
+                            if parent_space:
+                                chat_id = chat_id or getattr(parent_space, 'external_conversation_id', None)
+                                adapter_id = adapter_id or getattr(parent_space, 'adapter_id', None)
+                        
+                        if adapter_id and chat_id:
+                            # Send initial typing indicator
+                            space_registry.send_typing_indicator(adapter_id, chat_id, is_typing=True)
+                            logger.debug(f"[{self.agent_loop_name}] Sent initial typing indicator for {adapter_id}/{chat_id}")
+            except Exception as e:
+                logger.debug(f"[{self.agent_loop_name}] Could not send initial typing indicator: {e}")
 
             if focus_element_id:
                 logger.info(f"[{self.agent_loop_name}] Activation with focused context on element: {focus_element_id}")
@@ -260,6 +290,50 @@ class BaseAgentLoopComponent(Component):
             return self.parent_inner_space.id
 
         return None
+
+    def start_completion_tracking(self, adapter_id: str, chat_id: str, focus_element_id: Optional[str] = None) -> str:
+        """
+        Start tracking an active LLM completion for typing notifications.
+        
+        Args:
+            adapter_id: ID of the adapter for sending typing indicators
+            chat_id: ID of the chat/conversation
+            focus_element_id: Optional element ID that has focus
+            
+        Returns:
+            Unique completion ID for this tracking session
+        """
+        completion_id = str(uuid.uuid4())
+        self._active_completions[completion_id] = {
+            'start_time': time.time(),
+            'adapter_id': adapter_id,
+            'chat_id': chat_id,
+            'focus_element_id': focus_element_id
+        }
+        logger.debug(f"[{self.agent_loop_name}] Started tracking completion {completion_id[:8]} for {adapter_id}/{chat_id}")
+        return completion_id
+    
+    def end_completion_tracking(self, completion_id: str) -> None:
+        """
+        End tracking for a completed or failed LLM completion.
+        
+        Args:
+            completion_id: The ID returned from start_completion_tracking
+        """
+        if completion_id in self._active_completions:
+            context = self._active_completions[completion_id]
+            duration = time.time() - context['start_time']
+            logger.debug(f"[{self.agent_loop_name}] Ended tracking completion {completion_id[:8]} after {duration:.1f}s")
+            del self._active_completions[completion_id]
+    
+    def get_active_completions(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Get all currently active LLM completions being tracked.
+        
+        Returns:
+            Dictionary of completion_id -> context for all active completions
+        """
+        return self._active_completions.copy()
 
     def _resolve_prefix_to_element_id(self, prefix: str) -> Optional[str]:
         """

--- a/elements/elements/components/agent_loop/heartbeat_component.py
+++ b/elements/elements/components/agent_loop/heartbeat_component.py
@@ -5,7 +5,6 @@ from typing import Optional, Dict, Any, List, Tuple
 
 from ..base_component import Component
 from elements.component_registry import register_component
-from elements.space_registry import get_space_registry
 
 logger = logging.getLogger(__name__)
 
@@ -215,11 +214,7 @@ class HeartbeatComponent(Component):
 				self._last_typing_sent.clear()
 				return
 			
-			# Get the space registry for sending typing indicators
-			space_registry = get_space_registry()
-			if not space_registry:
-				logger.debug("No space registry available for typing indicators")
-				return
+			# We'll get the ActivityStatusComponent for each chat as needed
 			
 			# Process each active completion
 			current_time = time.time()
@@ -233,16 +228,25 @@ class HeartbeatComponent(Component):
 				# Check if we need to send/refresh typing for this chat
 				last_sent = self._last_typing_sent.get(chat_id, 0)
 				time_since_last = current_time - last_sent
-				
+
 				if time_since_last >= self._typing_refresh_interval:
-					# Send typing indicator
+					# Send typing indicator through ActivityStatusComponent
 					try:
-						success = space_registry.send_typing_indicator(adapter_id, chat_id, is_typing=True)
-						if success:
-							self._last_typing_sent[chat_id] = current_time
-							logger.debug(f"Sent typing indicator for {adapter_id}/{chat_id} (completion {completion_id[:8]})")
+						# Get ActivityStatusComponent from parent inner space
+						parent_inner_space = getattr(self.owner, 'get_parent_object', lambda: None)()
+						if parent_inner_space:
+							activity_status_component = parent_inner_space.get_component_by_type("ActivityStatusComponent")
+							if activity_status_component:
+								result = await activity_status_component.handle_typing_indicator(adapter_id, chat_id, is_typing=True)
+								if result.get("success"):
+									self._last_typing_sent[chat_id] = current_time
+									logger.debug(f"Sent typing indicator for {adapter_id}/{chat_id} (completion {completion_id[:8]})")
+								else:
+									logger.debug(f"Failed to send typing indicator for {adapter_id}/{chat_id}: {result.get('error')}")
+							else:
+								logger.debug(f"No ActivityStatusComponent found for typing indicator")
 						else:
-							logger.debug(f"Failed to send typing indicator for {adapter_id}/{chat_id}")
+							logger.debug(f"Could not get parent inner space for typing indicator")
 					except Exception as e:
 						logger.warning(f"Error sending typing indicator: {e}")
 			

--- a/elements/elements/components/agent_loop/heartbeat_component.py
+++ b/elements/elements/components/agent_loop/heartbeat_component.py
@@ -1,9 +1,11 @@
 import asyncio
 import logging
+import time
 from typing import Optional, Dict, Any, List, Tuple
 
 from ..base_component import Component
 from elements.component_registry import register_component
+from elements.space_registry import get_space_registry
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +23,10 @@ class HeartbeatComponent(Component):
 		self._preempt_flag = False
 		self._normal_queue: asyncio.Queue[Tuple[Dict[str, Any], Dict[str, Any]]] = asyncio.Queue()
 		self._interrupt_queue: asyncio.Queue[Tuple[Dict[str, Any], Dict[str, Any]]] = asyncio.Queue()
+		
+		# NEW: Track when typing indicators were last sent for each chat
+		self._last_typing_sent: Dict[str, float] = {}  # chat_id -> timestamp
+		self._typing_refresh_interval: float = 8.0  # Refresh typing every 8 seconds (Discord timeout is ~10s)
 
 	def initialize(self, **kwargs) -> None:
 		super().initialize(**kwargs)
@@ -91,6 +97,10 @@ class HeartbeatComponent(Component):
 					await self._process_pulse()
 					await self._refresh_hud_and_cache(self._collect_focus_candidates_from_decider())
 					await self._post_decider_evaluate()
+				
+				# NEW: Check for active LLM completions and send typing indicators
+				await self._check_and_send_typing_indicators()
+				
 				await asyncio.sleep(self._interval_ms / 1000.0)
 		except asyncio.CancelledError:
 			logger.debug("Heartbeat task cancelled")
@@ -184,4 +194,65 @@ class HeartbeatComponent(Component):
 			if decider and hasattr(decider, 'evaluate_and_maybe_activate'):
 				await decider.evaluate_and_maybe_activate({})
 		except Exception as e:
-			logger.debug(f"Heartbeat post-decider evaluate error: {e}") 
+			logger.debug(f"Heartbeat post-decider evaluate error: {e}")
+	
+	async def _check_and_send_typing_indicators(self) -> None:
+		"""
+		Check for active LLM completions and send typing indicators as needed.
+		This ensures typing indicators stay active during long LLM completions.
+		"""
+		try:
+			# Get the agent loop component
+			agent_loop = getattr(self.owner, '_agent_loop', None) if self.owner else None
+			if not agent_loop:
+				return
+			
+			# Check if there are active completions
+			active_completions = agent_loop.get_active_completions() if hasattr(agent_loop, 'get_active_completions') else {}
+			
+			if not active_completions:
+				# No active completions, clear our tracking
+				self._last_typing_sent.clear()
+				return
+			
+			# Get the space registry for sending typing indicators
+			space_registry = get_space_registry()
+			if not space_registry:
+				logger.debug("No space registry available for typing indicators")
+				return
+			
+			# Process each active completion
+			current_time = time.time()
+			for completion_id, context in active_completions.items():
+				adapter_id = context.get('adapter_id')
+				chat_id = context.get('chat_id')
+				
+				if not adapter_id or not chat_id:
+					continue
+				
+				# Check if we need to send/refresh typing for this chat
+				last_sent = self._last_typing_sent.get(chat_id, 0)
+				time_since_last = current_time - last_sent
+				
+				if time_since_last >= self._typing_refresh_interval:
+					# Send typing indicator
+					try:
+						success = space_registry.send_typing_indicator(adapter_id, chat_id, is_typing=True)
+						if success:
+							self._last_typing_sent[chat_id] = current_time
+							logger.debug(f"Sent typing indicator for {adapter_id}/{chat_id} (completion {completion_id[:8]})")
+						else:
+							logger.debug(f"Failed to send typing indicator for {adapter_id}/{chat_id}")
+					except Exception as e:
+						logger.warning(f"Error sending typing indicator: {e}")
+			
+			# Clean up old entries from _last_typing_sent for chats no longer active
+			active_chat_ids = {ctx.get('chat_id') for ctx in active_completions.values() if ctx.get('chat_id')}
+			self._last_typing_sent = {
+				chat_id: timestamp 
+				for chat_id, timestamp in self._last_typing_sent.items() 
+				if chat_id in active_chat_ids
+			}
+			
+		except Exception as e:
+			logger.debug(f"Error in typing indicator check: {e}") 

--- a/elements/elements/components/agent_loop/simple_request_response_loop.py
+++ b/elements/elements/components/agent_loop/simple_request_response_loop.py
@@ -109,41 +109,8 @@ class SimpleRequestResponseLoopComponent(BaseAgentLoopComponent):
                 logger.warning(f"Failed to cache LLM context: {cache_error}")
 
             # 4. Send rendered context + tools to LLM
-            # NEW: Extract typing context from focus_context or pipeline options
-            completion_id = None
-            try:
-                # Try to extract adapter and chat IDs from focus context
-                adapter_id = None
-                chat_id = None
-                
-                if focus_context:
-                    # Extract from focus_context which should have conversation info
-                    focus_element_id = focus_context.get('focus_element_id')
-                    if focus_element_id:
-                        # Get the element to find its conversation ID
-                        element = self.parent_inner_space.get_element_by_id(focus_element_id)
-                        if element:
-                            # Look for conversation ID in element or its parent
-                            chat_id = getattr(element, 'external_conversation_id', None) or \
-                                     getattr(element, 'conversation_id', None)
-                            adapter_id = getattr(element, 'adapter_id', None)
-                            
-                            # If not on element, check parent space
-                            if not adapter_id or not chat_id:
-                                parent_space = getattr(element, 'get_parent_object', lambda: None)()
-                                if parent_space:
-                                    chat_id = chat_id or getattr(parent_space, 'external_conversation_id', None)
-                                    adapter_id = adapter_id or getattr(parent_space, 'adapter_id', None)
-                
-                # Start tracking if we have the necessary context
-                if adapter_id and chat_id:
-                    completion_id = self.start_completion_tracking(adapter_id, chat_id, 
-                                                                  focus_context.get('focus_element_id') if focus_context else None)
-                    logger.debug(f"Started typing tracking for {adapter_id}/{chat_id}")
-                else:
-                    logger.debug(f"Could not extract typing context - adapter_id: {adapter_id}, chat_id: {chat_id}")
-            except Exception as e:
-                logger.warning(f"Error extracting typing context: {e}")
+            # Start typing notifications using base class method
+            completion_id = await self._start_typing_notifications(focus_context)
             
             # Metadata now travels with LLMMessage objects, no need for original_context_data
             try:

--- a/elements/elements/components/agent_loop/simple_request_response_loop.py
+++ b/elements/elements/components/agent_loop/simple_request_response_loop.py
@@ -109,8 +109,57 @@ class SimpleRequestResponseLoopComponent(BaseAgentLoopComponent):
                 logger.warning(f"Failed to cache LLM context: {cache_error}")
 
             # 4. Send rendered context + tools to LLM
+            # NEW: Extract typing context from focus_context or pipeline options
+            completion_id = None
+            try:
+                # Try to extract adapter and chat IDs from focus context
+                adapter_id = None
+                chat_id = None
+                
+                if focus_context:
+                    # Extract from focus_context which should have conversation info
+                    focus_element_id = focus_context.get('focus_element_id')
+                    if focus_element_id:
+                        # Get the element to find its conversation ID
+                        element = self.parent_inner_space.get_element_by_id(focus_element_id)
+                        if element:
+                            # Look for conversation ID in element or its parent
+                            chat_id = getattr(element, 'external_conversation_id', None) or \
+                                     getattr(element, 'conversation_id', None)
+                            adapter_id = getattr(element, 'adapter_id', None)
+                            
+                            # If not on element, check parent space
+                            if not adapter_id or not chat_id:
+                                parent_space = getattr(element, 'get_parent_object', lambda: None)()
+                                if parent_space:
+                                    chat_id = chat_id or getattr(parent_space, 'external_conversation_id', None)
+                                    adapter_id = adapter_id or getattr(parent_space, 'adapter_id', None)
+                
+                # Start tracking if we have the necessary context
+                if adapter_id and chat_id:
+                    completion_id = self.start_completion_tracking(adapter_id, chat_id, 
+                                                                  focus_context.get('focus_element_id') if focus_context else None)
+                    logger.debug(f"Started typing tracking for {adapter_id}/{chat_id}")
+                else:
+                    logger.debug(f"Could not extract typing context - adapter_id: {adapter_id}, chat_id: {chat_id}")
+            except Exception as e:
+                logger.warning(f"Error extracting typing context: {e}")
+            
             # Metadata now travels with LLMMessage objects, no need for original_context_data
-            llm_response_obj = llm_provider.complete(messages=messages, tools=aggregated_tools)
+            try:
+                llm_response_obj = llm_provider.complete(messages=messages, tools=aggregated_tools)
+                logger.debug(f"LLM completion successful, ending typing tracking")
+            except Exception as llm_error:
+                logger.error(f"LLM completion failed: {llm_error}", exc_info=True)
+                # End typing tracking on error
+                if completion_id:
+                    self.end_completion_tracking(completion_id)
+                raise llm_error
+            finally:
+                # Always end typing tracking after LLM completion (success or failure)
+                if completion_id:
+                    self.end_completion_tracking(completion_id)
+                    completion_id = None  # Clear to prevent double cleanup in finally block
 
             if not llm_response_obj:
                 logger.warning(f"{self.agent_loop_name} ({self.id}): LLM returned no response. Aborting cycle.")
@@ -212,4 +261,8 @@ class SimpleRequestResponseLoopComponent(BaseAgentLoopComponent):
         except Exception as e:
             logger.error(f"{self.agent_loop_name} ({self.id}): Error during simple cycle: {e}", exc_info=True)
         finally:
+            # Clean up typing tracking if it was started and not already cleaned up
+            if completion_id:
+                logger.debug(f"Final cleanup: ending completion tracking for {completion_id}")
+                self.end_completion_tracking(completion_id)
             logger.info(f"{self.agent_loop_name} ({self.id}): Simple cycle with memory completed.")

--- a/elements/elements/components/agent_loop/tool_text_parsing_loop.py
+++ b/elements/elements/components/agent_loop/tool_text_parsing_loop.py
@@ -89,6 +89,7 @@ class ToolTextParsingLoopComponent(BaseAgentLoopComponent):
         except Exception:
             pass
 
+        completion_id = None
         try:
             # 1. Aggregate tools and build element name mapping
             aggregated_tools = await self.aggregate_tools()
@@ -172,13 +173,26 @@ class ToolTextParsingLoopComponent(BaseAgentLoopComponent):
                 logger.warning(f"Failed to cache LLM context: {cache_error}")
 
             # 4. Send rendered context to LLM (no separate tool definitions - they're in the context)
+            # Start typing notifications using base class method
+            completion_id = await self._start_typing_notifications(focus_context)
+
             # NOTE: We don't pass tools parameter to LLM since they're already rendered in the context
             # Metadata now travels with LLMMessage objects, no need for original_context_data
-            if self._is_cancelled():
-                raise Exception("Agent loop preempted before LLM call")
-            llm_response_obj = llm_provider.complete(messages=messages, tools=[])
-            if self._is_cancelled():
-                raise Exception("Agent loop preempted after LLM call")
+            try:
+                if self._is_cancelled():
+                    raise Exception("Agent loop preempted before LLM call")
+                llm_response_obj = llm_provider.complete(messages=messages, tools=[])
+                if self._is_cancelled():
+                    raise Exception("Agent loop preempted after LLM call")
+            except Exception as llm_error:
+                # End typing tracking on error
+                if completion_id:
+                    self.end_completion_tracking(completion_id)
+                raise llm_error
+            finally:
+                # Always end typing tracking after LLM completion (success or failure)
+                if completion_id:
+                    self.end_completion_tracking(completion_id)
 
             if not llm_response_obj:
                 logger.warning(f"{self.agent_loop_name} ({self.id}): LLM returned no response. Aborting cycle.")
@@ -247,6 +261,10 @@ class ToolTextParsingLoopComponent(BaseAgentLoopComponent):
                 self._reset_cancel()
             logger.error(f"{self.agent_loop_name} ({self.id}): Error during text-parsing cycle: {e}", exc_info=True)
         finally:
+            # Clean up typing tracking if it was started
+            if completion_id:
+                logger.debug(f"Final cleanup: ending completion tracking for {completion_id}")
+                self.end_completion_tracking(completion_id)
             logger.info(f"{self.agent_loop_name} ({self.id}): Text-parsing cycle completed.")
 
     def _build_element_name_mapping(self, enhanced_tools: List[Dict[str, Any]]):

--- a/elements/elements/components/space/container_component.py
+++ b/elements/elements/components/space/container_component.py
@@ -146,6 +146,29 @@ class ContainerComponent(BaseComponent):
         """Gets all mounted elements with their mount info (element and mount_type)."""
         return self._state['_mounted_elements'].copy()
 
+    def get_mounted_elements_info(self) -> Dict[str, Dict[str, Any]]:
+        """Gets metadata about mounted elements without returning element objects.
+
+        Returns a mapping of mount_id to a metadata dict containing:
+        - element_id: str
+        - element_type: str
+        - mount_type: str
+        """
+        info: Dict[str, Dict[str, Any]] = {}
+        for mount_id, entry in self._state['_mounted_elements'].items():
+            element: Optional['BaseElement'] = entry.get('element')
+            mount_type = entry.get('mount_type')
+            mount_type_name = (
+                mount_type.name if isinstance(mount_type, MountType)
+                else (str(mount_type) if mount_type is not None else 'unknown')
+            )
+            info[mount_id] = {
+                'element_id': getattr(element, 'id', None),
+                'element_type': element.__class__.__name__ if element else 'Unknown',
+                'mount_type': mount_type_name
+            }
+        return info
+
     # --- VEIL Production (Optional) ---
     def produce_veil_structure(self) -> List[Dict[str, Any]]:
         """Produces a VEIL structure for the mounted elements."""

--- a/elements/elements/inner_space.py
+++ b/elements/elements/inner_space.py
@@ -31,6 +31,7 @@ from .components.agent_loop import BaseAgentLoopComponent, SimpleRequestResponse
 from .components.agent_loop.heartbeat_component import HeartbeatComponent
 from .components.agent_loop.decider_component import ActivationDeciderComponent
 from .components.agent_loop.interrupt_decider_component import InterruptDeciderComponent
+from .components.activity_status_component import ActivityStatusComponent
 
 # Type checking imports
 from typing import TYPE_CHECKING
@@ -199,15 +200,23 @@ class InnerSpace(Space):
             logger.error(f"Failed to add HeartbeatComponent to InnerSpace {self.id}")
         else:
             logger.info(f"HeartbeatComponent successfully added to InnerSpace {self.id}")
+
+        # Add ActivityStatusComponent for typing indicators and activity status
+        self._activity_status = self.add_component(ActivityStatusComponent)
+        if not self._activity_status:
+            logger.error(f"Failed to add ActivityStatusComponent to InnerSpace {self.id}")
+        else:
+            logger.info(f"ActivityStatusComponent successfully added to InnerSpace {self.id}")
         
         # Add any additional requested components
         if additional_components:
             for component_type in additional_components:
-                if component_type in [ToolProviderComponent, ElementFactoryComponent, 
+                if component_type in [ToolProviderComponent, ElementFactoryComponent,
                                      UplinkManagerComponent, # NEWLY ADDED
                                      VEILFacetCompressionEngine, # NEW: Add VEILFacet compression engine to skip list
                                      # GlobalAttentionComponent, # REMOVED
-                                     FacetAwareHUDComponent # NEW: Add FacetAware HUD to skip list
+                                     FacetAwareHUDComponent, # NEW: Add FacetAware HUD to skip list
+                                     ActivityStatusComponent, # Add ActivityStatusComponent to skip list
                                      # ContextManagerComponent # REMOVED
                                      ]:
                     # Skip components that we already added

--- a/elements/elements/inner_space.py
+++ b/elements/elements/inner_space.py
@@ -264,6 +264,7 @@ class InnerSpace(Space):
         self._propagate_callback_to_component(ElementFactoryComponent, callback)
         self._propagate_callback_to_component(UplinkManagerComponent, callback) # NEWLY ADDED
         self._propagate_callback_to_component(BaseAgentLoopComponent, callback)
+        self._propagate_callback_to_component(ActivityStatusComponent, callback) # Add ActivityStatusComponent
         # Add other components as needed
     
     def _propagate_callback_to_component(self, component_type: Type[Component], callback: 'OutgoingActionCallback') -> None:

--- a/elements/space_registry.py
+++ b/elements/space_registry.py
@@ -59,7 +59,6 @@ class SpaceRegistry:
         self._routing_map: Dict[str, str] = {}
         self.response_callback: Optional[Callable] = None
         self.space_observers: Dict[str, List[Callable]] = {}
-        self.activity_client: Optional[Any] = None
         
         # NEW: Storage integration for SpaceRegistry persistence
         self._storage: Optional[StorageInterface] = None
@@ -709,36 +708,8 @@ class SpaceRegistry:
             except Exception as e:
                 logger.error(f"Error propagating attention event to Shell: {e}")
     
-    def set_activity_client(self, activity_client) -> None:
-        """
-        Set the activity client for external communication.
-
-        Args:
-            activity_client: ActivityClient instance
-        """
-        self.activity_client = activity_client
-        logger.info("Activity client set in SpaceRegistry")
     
     
-    def send_typing_indicator(self, adapter_id: str, chat_id: str, is_typing: bool = True) -> bool:
-        """
-        Send a typing indicator to an external system.
-
-        Args:
-            adapter_id: ID of the adapter to send through
-            chat_id: ID of the chat/conversation
-            is_typing: Whether typing is active (True) or not (False)
-
-        Returns:
-            True if the indicator was sent successfully, False otherwise
-        """
-        if not self.activity_client:
-            logger.error("Cannot send typing indicator: No activity client set")
-            return False
-
-        logger.debug(f"Sending typing indicator ({is_typing}) for chat {chat_id} via adapter {adapter_id}")
-
-        return self.activity_client.send_typing_indicator(adapter_id, chat_id, is_typing)
     
     
 

--- a/elements/space_registry.py
+++ b/elements/space_registry.py
@@ -719,39 +719,6 @@ class SpaceRegistry:
         self.activity_client = activity_client
         logger.info("Activity client set in SpaceRegistry")
     
-    def send_external_message(self, message_data: Dict[str, Any]) -> bool:
-        """
-        Send a message to an external system.
-
-        This method serves as a central point for all outgoing messages,
-        routing them through the activity client.
-
-        Args:
-            message_data: Message data to send, with format:
-                {
-                    "event_type": "send_message",  # Or other event types
-                    "data": {
-                        "conversation_id": "C123",
-                        "text": "Hello world",
-                        # Other event-specific fields
-                    },
-                    "adapter_id": "adapter_id"
-                }
-
-        Returns:
-            True if the message was sent successfully, False otherwise
-        """
-        if not self.activity_client:
-            logger.error("Cannot send external message: No activity client set")
-            return False
-
-        # Log the outgoing message
-        event_type = message_data.get("event_type", "unknown")
-        adapter_id = message_data.get("adapter_id", "unknown")
-        logger.debug(f"Sending external {event_type} message via adapter {adapter_id}")
-
-        # Send through the activity client
-        return self.activity_client.send_message(message_data)
     
     def send_typing_indicator(self, adapter_id: str, chat_id: str, is_typing: bool = True) -> bool:
         """
@@ -773,54 +740,7 @@ class SpaceRegistry:
 
         return self.activity_client.send_typing_indicator(adapter_id, chat_id, is_typing)
     
-    def send_error(self, adapter_id: str, chat_id: str, error_message: str) -> bool:
-        """
-        Send an error message to an external system.
-
-        Args:
-            adapter_id: ID of the adapter to send through
-            chat_id: ID of the chat/conversation
-            error_message: Error message to send
-
-        Returns:
-            True if the error was sent successfully, False otherwise
-        """
-        if not self.activity_client:
-            logger.error("Cannot send error message: No activity client set")
-            return False
-
-        logger.debug(f"Sending error message for chat {chat_id} via adapter {adapter_id}: {error_message}")
-
-        return self.activity_client.send_error(adapter_id, chat_id, error_message)
     
-    def propagate_message(self, message: Dict[str, Any], timeline_context: Dict[str, Any]) -> bool:
-        """
-        Propagate a message from an element to the activity layer.
-        
-        Args:
-            message: Message to propagate
-            timeline_context: Timeline context for this message
-            
-        Returns:
-            True if propagation was successful, False otherwise
-        """
-        # Only propagate from primary timeline
-        if not timeline_context.get("is_primary", False):
-            logger.info(f"Not propagating message from non-primary timeline: {timeline_context.get('timeline_id')}")
-            return False
-            
-        # Send to activity client if available
-        if self.activity_client:
-            try:
-                self.activity_client.send_message(message)
-                logger.info("Propagated message to activity layer")
-                return True
-            except Exception as e:
-                logger.error(f"Error propagating message: {e}")
-                return False
-        else:
-            logger.warning("No activity client available for message propagation")
-            return False
 
     def get_or_create_shared_space(self, 
                                    identifier: str, 

--- a/elements/space_registry.py
+++ b/elements/space_registry.py
@@ -59,7 +59,7 @@ class SpaceRegistry:
         self._routing_map: Dict[str, str] = {}
         self.response_callback: Optional[Callable] = None
         self.space_observers: Dict[str, List[Callable]] = {}
-        self.socket_client: Optional[Any] = None
+        self.activity_client: Optional[Any] = None
         
         # NEW: Storage integration for SpaceRegistry persistence
         self._storage: Optional[StorageInterface] = None
@@ -709,23 +709,23 @@ class SpaceRegistry:
             except Exception as e:
                 logger.error(f"Error propagating attention event to Shell: {e}")
     
-    def set_socket_client(self, socket_client) -> None:
+    def set_activity_client(self, activity_client) -> None:
         """
-        Set the socket client for external communication.
-        
+        Set the activity client for external communication.
+
         Args:
-            socket_client: SocketIOClient instance
+            activity_client: ActivityClient instance
         """
-        self.socket_client = socket_client
-        logger.info("Socket client set in SpaceRegistry")
+        self.activity_client = activity_client
+        logger.info("Activity client set in SpaceRegistry")
     
     def send_external_message(self, message_data: Dict[str, Any]) -> bool:
         """
         Send a message to an external system.
-        
+
         This method serves as a central point for all outgoing messages,
-        routing them through the socket client.
-        
+        routing them through the activity client.
+
         Args:
             message_data: Message data to send, with format:
                 {
@@ -737,61 +737,61 @@ class SpaceRegistry:
                     },
                     "adapter_id": "adapter_id"
                 }
-                
+
         Returns:
             True if the message was sent successfully, False otherwise
         """
-        if not self.socket_client:
-            logger.error("Cannot send external message: No socket client set")
+        if not self.activity_client:
+            logger.error("Cannot send external message: No activity client set")
             return False
-            
+
         # Log the outgoing message
         event_type = message_data.get("event_type", "unknown")
         adapter_id = message_data.get("adapter_id", "unknown")
         logger.debug(f"Sending external {event_type} message via adapter {adapter_id}")
-        
-        # Send through the socket client
-        return self.socket_client.send_message(message_data)
+
+        # Send through the activity client
+        return self.activity_client.send_message(message_data)
     
     def send_typing_indicator(self, adapter_id: str, chat_id: str, is_typing: bool = True) -> bool:
         """
         Send a typing indicator to an external system.
-        
+
         Args:
             adapter_id: ID of the adapter to send through
             chat_id: ID of the chat/conversation
             is_typing: Whether typing is active (True) or not (False)
-            
+
         Returns:
             True if the indicator was sent successfully, False otherwise
         """
-        if not self.socket_client:
-            logger.error("Cannot send typing indicator: No socket client set")
+        if not self.activity_client:
+            logger.error("Cannot send typing indicator: No activity client set")
             return False
-            
+
         logger.debug(f"Sending typing indicator ({is_typing}) for chat {chat_id} via adapter {adapter_id}")
-        
-        return self.socket_client.send_typing_indicator(adapter_id, chat_id, is_typing)
+
+        return self.activity_client.send_typing_indicator(adapter_id, chat_id, is_typing)
     
     def send_error(self, adapter_id: str, chat_id: str, error_message: str) -> bool:
         """
         Send an error message to an external system.
-        
+
         Args:
             adapter_id: ID of the adapter to send through
             chat_id: ID of the chat/conversation
             error_message: Error message to send
-            
+
         Returns:
             True if the error was sent successfully, False otherwise
         """
-        if not self.socket_client:
-            logger.error("Cannot send error message: No socket client set")
+        if not self.activity_client:
+            logger.error("Cannot send error message: No activity client set")
             return False
-            
+
         logger.debug(f"Sending error message for chat {chat_id} via adapter {adapter_id}: {error_message}")
-        
-        return self.socket_client.send_error(adapter_id, chat_id, error_message)
+
+        return self.activity_client.send_error(adapter_id, chat_id, error_message)
     
     def propagate_message(self, message: Dict[str, Any], timeline_context: Dict[str, Any]) -> bool:
         """
@@ -809,17 +809,17 @@ class SpaceRegistry:
             logger.info(f"Not propagating message from non-primary timeline: {timeline_context.get('timeline_id')}")
             return False
             
-        # Send to socket client if available
-        if self.socket_client:
+        # Send to activity client if available
+        if self.activity_client:
             try:
-                self.socket_client.send_message(message)
+                self.activity_client.send_message(message)
                 logger.info("Propagated message to activity layer")
                 return True
             except Exception as e:
                 logger.error(f"Error propagating message: {e}")
                 return False
         else:
-            logger.warning("No socket client available for message propagation")
+            logger.warning("No activity client available for message propagation")
             return False
 
     def get_or_create_shared_space(self, 
@@ -898,3 +898,9 @@ class SpaceRegistry:
         except Exception as e:
             logger.error(f"Exception during SharedSpace creation for identifier '{identifier}': {e}", exc_info=True)
             return None
+
+
+# NEW: Global function to get the singleton instance
+def get_space_registry() -> Optional[SpaceRegistry]:
+    """Get the singleton SpaceRegistry instance, if it exists."""
+    return SpaceRegistry._instance

--- a/host/main.py
+++ b/host/main.py
@@ -207,9 +207,6 @@ async def amain():
     external_event_router.set_activity_client(activity_client)
     logger.info("ExternalEventRouter configured with ActivityClient reference for action preprocessing")
 
-    # NEW: Set ActivityClient reference in SpaceRegistry (for typing indicators and external messaging)
-    space_registry.set_activity_client(activity_client)
-    logger.info("SpaceRegistry configured with ActivityClient for typing indicator support")
     
     # After component scanning, we can validate agent configurations
     logger.info("Processing agent configurations...")

--- a/host/main.py
+++ b/host/main.py
@@ -206,6 +206,10 @@ async def amain():
     # NEW: Set ActivityClient reference in ExternalEventRouter for outgoing action dispatch
     external_event_router.set_activity_client(activity_client)
     logger.info("ExternalEventRouter configured with ActivityClient reference for action preprocessing")
+
+    # NEW: Set ActivityClient reference in SpaceRegistry (for typing indicators and external messaging)
+    space_registry.set_activity_client(activity_client)
+    logger.info("SpaceRegistry configured with ActivityClient for typing indicator support")
     
     # After component scanning, we can validate agent configurations
     logger.info("Processing agent configurations...")

--- a/host/modules/activities/activity_client.py
+++ b/host/modules/activities/activity_client.py
@@ -1243,3 +1243,98 @@ class ActivityClient:
                 setattr(self, f'_timeout_count_{adapter_id}', 0)
                 # Reset success counter to prevent it from growing indefinitely
                 self._successful_operations[adapter_id] = 0
+
+    # NEW: Methods for SpaceRegistry socket client compatibility
+    def send_message(self, message_data: Dict[str, Any]) -> bool:
+        """
+        Send a message via the activity client (compatibility method for space registry).
+
+        Args:
+            message_data: Message data with format expected by activity client
+
+        Returns:
+            True if message was queued successfully, False otherwise
+        """
+        try:
+            # Create an action from the message data for handle_outgoing_action
+            action = {
+                "payload": message_data
+            }
+
+            # Queue the action via handle_outgoing_action
+            asyncio.create_task(self.handle_outgoing_action(action))
+            return True
+
+        except Exception as e:
+            logger.error(f"Error sending message via ActivityClient: {e}")
+            return False
+
+    def send_typing_indicator(self, adapter_id: str, chat_id: str, is_typing: bool = True) -> bool:
+        """
+        Send a typing indicator to an external adapter.
+
+        Args:
+            adapter_id: ID of the adapter to send through
+            chat_id: ID of the chat/conversation
+            is_typing: Whether typing is active (True) or not (False)
+
+        Returns:
+            True if the indicator was queued successfully, False otherwise
+        """
+        try:
+            # Create typing indicator action payload
+            typing_payload = {
+                "action_type": "send_typing_indicator",
+                "adapter_id": adapter_id,
+                "conversation_id": chat_id,
+                "is_typing": is_typing,
+                "internal_request_id": f"typing_{adapter_id}_{chat_id}_{int(time.time())}"
+            }
+
+            action = {
+                "payload": typing_payload
+            }
+
+            # Queue the action via handle_outgoing_action
+            asyncio.create_task(self.handle_outgoing_action(action))
+            logger.debug(f"Queued typing indicator ({is_typing}) for {adapter_id}/{chat_id}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error sending typing indicator via ActivityClient: {e}")
+            return False
+
+    def send_error(self, adapter_id: str, chat_id: str, error_message: str) -> bool:
+        """
+        Send an error message to an external adapter.
+
+        Args:
+            adapter_id: ID of the adapter to send through
+            chat_id: ID of the chat/conversation
+            error_message: Error message to send
+
+        Returns:
+            True if the error was queued successfully, False otherwise
+        """
+        try:
+            # Create error message action payload
+            error_payload = {
+                "action_type": "send_message",
+                "adapter_id": adapter_id,
+                "conversation_id": chat_id,
+                "text": f"⚠️ Error: {error_message}",
+                "internal_request_id": f"error_{adapter_id}_{chat_id}_{int(time.time())}"
+            }
+
+            action = {
+                "payload": error_payload
+            }
+
+            # Queue the action via handle_outgoing_action
+            asyncio.create_task(self.handle_outgoing_action(action))
+            logger.debug(f"Queued error message for {adapter_id}/{chat_id}: {error_message}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error sending error message via ActivityClient: {e}")
+            return False

--- a/host/modules/activities/activity_client.py
+++ b/host/modules/activities/activity_client.py
@@ -77,7 +77,7 @@ class ActivityClient:
         self._pending_io_requests: Dict[str, Dict[str, Any]] = {}
 
         # NEW: Keepalive and idle state management
-        self._keepalive_interval = 30  # Send keepalive every 30 seconds (must be less than Socket.IO timeout of 60s)
+        self._keepalive_interval = 5   # Send keepalive every 5 seconds (local adapter, high-frequency monitoring)
         self._idle_threshold = 300  # Consider connection idle after 5 minutes
         self._last_activity: Dict[str, float] = {}  # adapter_id -> timestamp of last activity
         self._keepalive_tasks: Dict[str, asyncio.Task] = {}  # adapter_id -> keepalive task
@@ -834,14 +834,8 @@ class ActivityClient:
                     if hasattr(client.eio, 'state') and client.eio.state != 'connected':
                         connection_issues.append(f"Engine.IO state is '{client.eio.state}', not 'connected'")
 
-                    # Check packet queue state more thoroughly
+                    # Check if transport is available and healthy
                     if hasattr(client.eio, 'queue'):
-                        if hasattr(client.eio.queue, 'empty') and client.eio.queue.empty():
-                            connection_issues.append("Engine.IO packet queue is empty")
-                        elif hasattr(client.eio.queue, 'qsize') and client.eio.queue.qsize() == 0:
-                            connection_issues.append("Engine.IO packet queue size is 0")
-
-                        # Check if transport is available and healthy
                         if hasattr(client.eio, 'transport') and client.eio.transport:
                             if hasattr(client.eio.transport, 'state') and client.eio.transport.state != 'open':
                                 connection_issues.append(f"Transport state is '{client.eio.transport.state}', not 'open'")

--- a/host/modules/activities/activity_client.py
+++ b/host/modules/activities/activity_client.py
@@ -1245,29 +1245,6 @@ class ActivityClient:
                 self._successful_operations[adapter_id] = 0
 
     # NEW: Methods for SpaceRegistry socket client compatibility
-    def send_message(self, message_data: Dict[str, Any]) -> bool:
-        """
-        Send a message via the activity client (compatibility method for space registry).
-
-        Args:
-            message_data: Message data with format expected by activity client
-
-        Returns:
-            True if message was queued successfully, False otherwise
-        """
-        try:
-            # Create an action from the message data for handle_outgoing_action
-            action = {
-                "payload": message_data
-            }
-
-            # Queue the action via handle_outgoing_action
-            asyncio.create_task(self.handle_outgoing_action(action))
-            return True
-
-        except Exception as e:
-            logger.error(f"Error sending message via ActivityClient: {e}")
-            return False
 
     def send_typing_indicator(self, adapter_id: str, chat_id: str, is_typing: bool = True) -> bool:
         """
@@ -1304,37 +1281,3 @@ class ActivityClient:
             logger.error(f"Error sending typing indicator via ActivityClient: {e}")
             return False
 
-    def send_error(self, adapter_id: str, chat_id: str, error_message: str) -> bool:
-        """
-        Send an error message to an external adapter.
-
-        Args:
-            adapter_id: ID of the adapter to send through
-            chat_id: ID of the chat/conversation
-            error_message: Error message to send
-
-        Returns:
-            True if the error was queued successfully, False otherwise
-        """
-        try:
-            # Create error message action payload
-            error_payload = {
-                "action_type": "send_message",
-                "adapter_id": adapter_id,
-                "conversation_id": chat_id,
-                "text": f"⚠️ Error: {error_message}",
-                "internal_request_id": f"error_{adapter_id}_{chat_id}_{int(time.time())}"
-            }
-
-            action = {
-                "payload": error_payload
-            }
-
-            # Queue the action via handle_outgoing_action
-            asyncio.create_task(self.handle_outgoing_action(action))
-            logger.debug(f"Queued error message for {adapter_id}/{chat_id}: {error_message}")
-            return True
-
-        except Exception as e:
-            logger.error(f"Error sending error message via ActivityClient: {e}")
-            return False

--- a/host/modules/activities/activity_client.py
+++ b/host/modules/activities/activity_client.py
@@ -1246,38 +1246,4 @@ class ActivityClient:
 
     # NEW: Methods for SpaceRegistry socket client compatibility
 
-    def send_typing_indicator(self, adapter_id: str, chat_id: str, is_typing: bool = True) -> bool:
-        """
-        Send a typing indicator to an external adapter.
-
-        Args:
-            adapter_id: ID of the adapter to send through
-            chat_id: ID of the chat/conversation
-            is_typing: Whether typing is active (True) or not (False)
-
-        Returns:
-            True if the indicator was queued successfully, False otherwise
-        """
-        try:
-            # Create typing indicator action payload
-            typing_payload = {
-                "action_type": "send_typing_indicator",
-                "adapter_id": adapter_id,
-                "conversation_id": chat_id,
-                "is_typing": is_typing,
-                "internal_request_id": f"typing_{adapter_id}_{chat_id}_{int(time.time())}"
-            }
-
-            action = {
-                "payload": typing_payload
-            }
-
-            # Queue the action via handle_outgoing_action
-            asyncio.create_task(self.handle_outgoing_action(action))
-            logger.debug(f"Queued typing indicator ({is_typing}) for {adapter_id}/{chat_id}")
-            return True
-
-        except Exception as e:
-            logger.error(f"Error sending typing indicator via ActivityClient: {e}")
-            return False
 

--- a/host/modules/activities/protocol/fix_protocol.py
+++ b/host/modules/activities/protocol/fix_protocol.py
@@ -13,6 +13,8 @@ from enum import Enum
 from typing import Dict, Any, Optional, Callable, List, Set
 from collections import OrderedDict
 
+from opentelemetry import trace
+
 
 class MessageDirection(Enum):
     OUTBOUND = "outbound"
@@ -111,7 +113,10 @@ class FIXProtocol:
         
         # Logger
         self.logger = logging.getLogger(f"FIXProtocol.{node_id}")
-        
+
+        # Tracer
+        self.tracer = trace.get_tracer(f"FIXProtocol.{node_id}")
+
         # Start cleanup task
         self.cleanup_task = asyncio.create_task(self._cleanup_old_messages())
         
@@ -122,46 +127,63 @@ class FIXProtocol:
             self.logger.info(f"Created new peer state for {peer_id}")
         return self.peer_states[peer_id]
         
-    async def send_message(self, 
+    async def send_message(self,
                           message_type: str,
                           body: Dict[str, Any],
                           peer_id: Optional[str] = None,
                           requires_ack: bool = False) -> int:
         """
         Send a message with protocol headers.
-        
+
         Args:
             message_type: Type of message (e.g., "bot_request", "bot_response")
             body: Message payload
             peer_id: Target peer (for directed messages)
             requires_ack: Whether explicit acknowledgment is required
-            
+
         Returns:
             Sequence number assigned to the message
         """
-        self.logger.info(f"BEFORE increment: outbound_sequence={self.outbound_sequence}")
-        self.outbound_sequence += 1
-        self.logger.info(f"AFTER increment: outbound_sequence={self.outbound_sequence}")
-        
-        # Create protocol message
-        message = ProtocolMessage(
-            sequence=self.outbound_sequence,
-            timestamp=time.time(),
-            message_type=message_type,
-            sender=self.node_id,
-            body=body,
-            requires_ack=requires_ack
-        )
-        
-        # Store for retransmission
-        self.message_storage[self.outbound_sequence] = message
-        
-        # Send via transport
-        await self.send_callback('protocol_message', message.to_dict())
-        
-        self.logger.debug(f"Sent {message_type} with seq={self.outbound_sequence}")
-        
-        return self.outbound_sequence
+        with self.tracer.start_as_current_span("fix_protocol.send_message") as span:
+            span.set_attribute("message_type", message_type)
+            span.set_attribute("node_id", self.node_id)
+            span.set_attribute("requires_ack", requires_ack)
+            if peer_id:
+                span.set_attribute("peer_id", peer_id)
+
+            self.logger.info(f"BEFORE increment: outbound_sequence={self.outbound_sequence}")
+            span.add_event("incrementing_sequence")
+            self.outbound_sequence += 1
+            span.set_attribute("sequence_number", self.outbound_sequence)
+            self.logger.info(f"AFTER increment: outbound_sequence={self.outbound_sequence}")
+
+            # Create protocol message
+            span.add_event("creating_protocol_message")
+            message_timestamp = time.time()
+            span.set_attribute("message_timestamp", message_timestamp)
+
+            message = ProtocolMessage(
+                sequence=self.outbound_sequence,
+                timestamp=message_timestamp,
+                message_type=message_type,
+                sender=self.node_id,
+                body=body,
+                requires_ack=requires_ack
+            )
+
+            # Store for retransmission
+            span.add_event("storing_for_retransmission")
+            self.message_storage[self.outbound_sequence] = message
+
+            # Send via transport
+            span.add_event("sending_via_transport")
+            await self.send_callback('protocol_message', message.to_dict())
+            span.add_event("transport_send_completed")
+
+            self.logger.debug(f"Sent {message_type} with seq={self.outbound_sequence}")
+
+            span.set_status(trace.Status(trace.StatusCode.OK))
+            return self.outbound_sequence
         
     async def handle_incoming_message(self, peer_id: str, data: Dict[str, Any]) -> None:
         """

--- a/host/modules/activities/protocol/protocol_persistence.py
+++ b/host/modules/activities/protocol/protocol_persistence.py
@@ -13,6 +13,8 @@ from typing import Dict, Any, Optional, List
 from dataclasses import asdict
 import logging
 
+from opentelemetry import trace
+
 from .fix_protocol import ProtocolMessage, ProtocolState
 
 
@@ -276,6 +278,7 @@ class PersistentFIXProtocol:
         self.protocol = protocol
         self.persistence = persistence
         self.logger = logging.getLogger(f"PersistentProtocol.{protocol.node_id}")
+        self.tracer = trace.get_tracer(f"PersistentProtocol.{protocol.node_id}")
         
     async def initialize(self):
         """Load persisted state on startup"""
@@ -324,16 +327,33 @@ class PersistentFIXProtocol:
         
     async def send_message(self, *args, **kwargs) -> int:
         """Send message and persist"""
-        sequence = await self.protocol.send_message(*args, **kwargs)
-        
-        # Persist the message
-        message = self.protocol.message_storage[sequence]
-        await self.persistence.save_message(self.protocol.node_id, sequence, message)
-        
-        # Update state
-        await self.save_state()
-        
-        return sequence
+        with self.tracer.start_as_current_span("persistent_protocol.send_message") as span:
+            span.set_attribute("node_id", self.protocol.node_id)
+
+            # Extract message_type if available for better tracing
+            if len(args) > 0:
+                span.set_attribute("message_type", args[0])
+            elif 'message_type' in kwargs:
+                span.set_attribute("message_type", kwargs['message_type'])
+
+            span.add_event("calling_protocol_send_message")
+            sequence = await self.protocol.send_message(*args, **kwargs)
+            span.set_attribute("sequence_number", sequence)
+            span.add_event("protocol_send_completed")
+
+            # Persist the message
+            span.add_event("persisting_message")
+            message = self.protocol.message_storage[sequence]
+            await self.persistence.save_message(self.protocol.node_id, sequence, message)
+            span.add_event("message_persisted")
+
+            # Update state
+            span.add_event("saving_state")
+            await self.save_state()
+            span.add_event("state_saved")
+
+            span.set_status(trace.Status(trace.StatusCode.OK))
+            return sequence
         
     async def handle_incoming_message(self, peer_id: str, data: Dict[str, Any]) -> None:
         """Handle incoming message and update persistent state"""

--- a/host/routing/external_event_router.py
+++ b/host/routing/external_event_router.py
@@ -1335,6 +1335,12 @@ class ExternalEventRouter:
                 "attachment_id": payload.get("attachment_id")
             })
 
+        elif action_type == "send_typing_indicator":
+            clean_payload.update({
+                "conversation_id": conversation_id
+                # Note: is_typing field omitted - adapter protocol only expects conversation_id
+            })
+
         else:
             logger.warning(f"Unknown action_type '{action_type}' in outgoing action preprocessing. Passing through with minimal changes.")
             clean_payload.update(payload)  # Pass through unknown actions


### PR DESCRIPTION
Primary change: implements typing notification sending (for adapters that support it)

Secondary changes:

- Connection health tracking would check if socket engine queue has zero events. This is a normal situation when all events are processed, so it would cause connection restart on every adapter message, adding to the already significant total message delay. Replaced it with more frequent polling.

- Added a missing `get_elements_info` method to squash a `Error extracting expected elements: 'ContainerComponent' object has no attribute 'get_mounted_elements_info'` on boot.

---

How it works:

- Typing intent is initiated in the agent loop
  - Base loop calls `_start_typing_notifications(...)` when beginning an LLM completion, extracting `adapter_id` and `conversation_id` from focus, and immediately sends an initial typing signal via `ActivityStatusComponent`.
  - File: `elements/elements/components/agent_loop/base_agent_loop_component.py` (see `_start_typing_notifications`)

- InnerSpace wires the action path
  - `InnerSpace` adds `ActivityStatusComponent` and propagates its `outgoing_action_callback` so components can dispatch actions outward.
  - File: `elements/elements/inner_space.py` (adds `ActivityStatusComponent`, sets callback)

- ActivityStatusComponent issues the typing action
  - `ActivityStatusComponent.handle_typing_indicator(adapter_id, conversation_id, is_typing=True)` builds an action: `action_type="send_typing_indicator"`, `target_module="ActivityClient"`, and includes `internal_request_id`, `requesting_element_id`, `adapter_id`, `conversation_id`, `is_typing`.
  - File: `elements/elements/components/activity_status_component.py` (`handle_typing_indicator`)

- ExternalEventRouter preprocesses the action
  - `ExternalEventRouter.handle_outgoing_action(...)` stores routing context by `internal_request_id`, then produces a “clean” payload for the thin I/O layer.
  - For `send_typing_indicator`, it forwards only `conversation_id` (note: `is_typing` omitted by protocol expectation).
  - File: `host/routing/external_event_router.py` (`handle_outgoing_action`, case `send_typing_indicator`)

- ActivityClient sends to the adapter
  - `ActivityClient.handle_outgoing_action(...)` validates connectivity, records minimal pending I/O state, and emits a Socket.IO `bot_response` with:
    - `event_type: "send_typing_indicator"`
    - `internal_request_id`
    - `data: { adapter_id, conversation_id, ... }`
  - Protocol layer may wrap this; otherwise a direct emit is used.
  - File: `host/modules/activities/activity_client.py` (`handle_outgoing_action`)

- Heartbeat keeps typing “alive” during long completions
  - `HeartbeatComponent.run()` periodically calls `_check_and_send_typing_indicators()`.
  - It refreshes typing signals every ~8s for each active LLM completion tracked by the agent loop (to prevent platform timeouts like Discord’s ~10s).
  - File: `elements/elements/components/agent_loop/heartbeat_component.py` (`_check_and_send_typing_indicators`)
  
I haven't been able to test this with a completion taking more than 8s yet, so the heartbeat ping is not really tested.

- Completion end stops typing refresh
  - The agent loop tracks active completions; when a completion finishes (success or error), it ends tracking, so Heartbeat no longer refreshes typing for that chat.
  - File: `elements/elements/components/agent_loop/base_agent_loop_component.py` (completion tracking lifecycle; invoked by specific loop implementations such as `simple_request_response_loop.py` and `tool_text_parsing_loop.py`)